### PR TITLE
Restore clean-clone MGX quality gate

### DIFF
--- a/docs/development/MGX_TEST_TIERS.md
+++ b/docs/development/MGX_TEST_TIERS.md
@@ -1,0 +1,31 @@
+# MGX Test Tiers
+
+## Clean-clone quality gate
+
+Run the following from a clean checkout:
+
+```bash
+npm ci --legacy-peer-deps
+npm run lint
+npm test
+npm run test:mgx:safety
+npm run build
+```
+
+`npm test` contains suites that are reproducible from Git-tracked source and
+fixtures. It must pass in a clean clone and must not require local AI corpora.
+
+## Local AI artifact validation
+
+Run this only after restoring or regenerating the ignored AI datasets and
+reports referenced by the Step 37–51 evaluation pipeline:
+
+```bash
+npm run test:artifacts
+```
+
+These suites are kept separate because `.gitignore` intentionally excludes
+large or generated files under `data/ai/**/*.jsonl`,
+`reports/ai-iron/**/*.json`, and `reports/ai-iron/**/*.jsonl`. A missing local
+corpus is an artifact-readiness failure, not a clean-clone source regression.
+The artifact gate must still pass before promoting or routing an AI model.

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "lint": "eslint .",
     "preview": "vite preview",
     "test": "vitest run",
+    "test:artifacts": "vitest run --config vitest.artifacts.config.js",
     "test:game:progress": "vitest run src/games/testing/progress src/games/testing/regression src/games/testing/scenario",
     "test:game:known-bugs": "vitest run src/games/testing/regression/gameProgressKnownBugs.test.js",
     "test:game:family": "vitest run src/games/testing/scenario/*FamilyProgress.test.js",

--- a/src/RootApp.jsx
+++ b/src/RootApp.jsx
@@ -15,7 +15,7 @@ import FriendMatchSetupScreen from "./ui/screens/FriendMatchSetupScreen.jsx";
 import LeaderboardScreen from "./ui/screens/LeaderboardScreen.jsx";
 import LearningDashboardPreviewScreen from "./ui/screens/LearningDashboardPreviewScreen.jsx";
 import { isCoachingPreviewEnabled } from "./ui/coaching/previewFeatureFlags.js";
-import { GameEngineProvider } from "./ui/engine/GameEngineContext";
+import { GameEngineProvider } from "./ui/engine/GameEngineContext.jsx";
 import { MixedGameProvider } from "./ui/mixed/MixedGameContext.jsx";
 
 export default function RootApp() {

--- a/src/ai/evaluation/__tests__/runProVsStandardEvaluationCli.test.js
+++ b/src/ai/evaluation/__tests__/runProVsStandardEvaluationCli.test.js
@@ -1,3 +1,7 @@
+import os from "node:os";
+import path from "node:path";
+import fs from "node:fs/promises";
+
 import { describe, expect, it } from "vitest";
 
 import { runEvaluationCli } from "../runProVsStandardEvaluation.js";
@@ -10,7 +14,10 @@ describe("AI pro evaluation CLI", () => {
       typeof variantArg === "string" && variantArg.length
         ? variantArg.replace("--variants=", "").split(",").map((entry) => entry.trim()).filter(Boolean)
         : ["D03"];
-    const { summary, outputPath } = await runEvaluationCli(forwardedArgs);
+    const outputDirectory = await fs.mkdtemp(path.join(os.tmpdir(), "mgx-pro-eval-"));
+    const { summary, outputPath } = await runEvaluationCli(forwardedArgs, {
+      outputPath: path.join(outputDirectory, "evaluation.json"),
+    });
     expect(summary.runId).toMatch(/^pro-vs-standard-\d+$/);
     expect(summary.variants[expectedVariants[0]]).toBeTruthy();
     expect(typeof outputPath).toBe("string");

--- a/src/ai/evaluation/runProVsStandardEvaluation.js
+++ b/src/ai/evaluation/runProVsStandardEvaluation.js
@@ -91,10 +91,13 @@ async function withMutedConsole(callback) {
   }
 }
 
-export async function runEvaluationCli(argv = process.argv.slice(2)) {
+export async function runEvaluationCli(
+  argv = process.argv.slice(2),
+  { outputPath: outputPathOverride } = {},
+) {
   const options = parseArgs(argv);
   const report = await withMutedConsole(() => runProVsStandardEvaluationSuite(options));
-  const outputPath = getDefaultEvalOutputPath(options.seed);
+  const outputPath = outputPathOverride ?? getDefaultEvalOutputPath(options.seed);
   await writeEvaluationJson(report, outputPath);
   await writeDivergenceReplaySamples(report, { seed: options.seed });
   return {

--- a/src/ai/iron/detectIronBenchmarkDrift.js
+++ b/src/ai/iron/detectIronBenchmarkDrift.js
@@ -95,7 +95,7 @@ export function detectIronBenchmarkDrift({
   const determinism = current?.determinism ?? {};
   pushCheck(
     "deterministicReplay",
-    Boolean(determinism?.deterministic) ? "PASS" : "FAIL",
+    determinism?.deterministic ? "PASS" : "FAIL",
     `value=${Boolean(determinism?.deterministic)}`,
   );
   pushCheck(

--- a/src/ui/App.jsx
+++ b/src/ui/App.jsx
@@ -588,6 +588,7 @@ export default function App() {
   const gameControllerRef = useRef(null);
   const controllerVariantRef = useRef(null);
   const controllerStreetRef = useRef(null);
+  const lastControllerActionFailureRef = useRef(null);
   const studStreetPauseUntilRef = useRef(0);
   const [studStreetPauseToken, setStudStreetPauseToken] = useState(0);
   const uiAdapterRef = useRef(null);

--- a/vitest.artifacts.config.js
+++ b/vitest.artifacts.config.js
@@ -1,0 +1,13 @@
+import { defineConfig, mergeConfig } from "vitest/config";
+
+import baseConfig, { artifactDependentTests } from "./vitest.config.js";
+
+export default mergeConfig(
+  baseConfig,
+  defineConfig({
+    test: {
+      include: artifactDependentTests,
+      exclude: ["node_modules", "dist"],
+    },
+  }),
+);

--- a/vitest.config.js
+++ b/vitest.config.js
@@ -1,8 +1,37 @@
 import { defineConfig } from "vitest/config";
 
+// These suites validate locally generated AI corpora and reports that are
+// intentionally excluded from Git. Run them with `npm run test:artifacts`
+// after restoring or regenerating the required datasets.
+export const artifactDependentTests = [
+  "src/ui/screens/__tests__/ReplayScreen.coachingRealFixture.test.jsx",
+  "src/ai/evaluation/__tests__/actionValueDataset.test.js",
+  "src/ai/iron/__tests__/acquireS02DeepPlayerCountReplay.test.js",
+  "src/ai/iron/__tests__/buildS02DeepPreExportRows.test.js",
+  "src/ai/iron/__tests__/finalizeActionValueDatasetDiff.test.js",
+  "src/ai/iron/__tests__/forcedActionReplayHarness.test.js",
+  "src/ai/iron/__tests__/previewActionValueDatasetDiff.test.js",
+  "src/ai/iron/__tests__/refreshDatasetConcentrationRisk.test.js",
+  "src/ai/iron/__tests__/replayS02DeepPlayerCountBranches.test.js",
+  "src/ai/iron/__tests__/runForcedActionReplay.test.js",
+  "src/ai/iron/__tests__/runS02StackDepthForcedReplay.test.js",
+  "src/ai/iron/__tests__/s02LowerMediumForcedReplay.test.js",
+  "src/ai/iron/__tests__/validatePreExportPackage.test.js",
+  "src/ai/iron/__tests__/variantBalancedDataset.test.js",
+  "src/ai/iron/__tests__/writeApprovedActionValueDataset.test.js",
+  "src/ui/coaching/__tests__/buildRealReplayCoachingFixture.test.js",
+];
+
 export default defineConfig({
   test: {
-    exclude: ["node_modules", "dist", "e2e/**", "tests/e2e/**", "tests/badugi-regression/**"],
+    exclude: [
+      "node_modules",
+      "dist",
+      "e2e/**",
+      "tests/e2e/**",
+      "tests/badugi-regression/**",
+      ...artifactDependentTests,
+    ],
     environment: "jsdom",
     reporters: ["dot"],
   },


### PR DESCRIPTION
## Summary
- fix case-sensitive GameEngineProvider import and missing controller failure ref
- fix the remaining ESLint error
- separate local AI-corpus validation from clean-clone source tests
- stop the CLI test from overwriting a tracked evaluation report
- document clean-clone and artifact-dependent test tiers

## Verification
- clean worktree from commit 8ae95cc
- npm ci --legacy-peer-deps: PASS
- npm run lint: PASS (0 errors, 21 pre-existing warnings)
- npm test: PASS (1,685 passed, 11 skipped)
- npm run test:mgx:safety: PASS (52 passed)
- npm run build: PASS
- git status after all gates: clean

## Known boundary
The 16 artifact-dependent suites remain available under npm run test:artifacts and require ignored Step 37–51 local corpora. No model promotion or routing change is included.