### PR TITLE
Document MGX-SEC-001 dependency triage

### DIFF
--- a/docs/security/MGX-SEC-001-DEPENDENCY-TRIAGE-20260811.md
+++ b/docs/security/MGX-SEC-001-DEPENDENCY-TRIAGE-20260811.md
@@ -1,0 +1,48 @@
+# MGX-SEC-001 Dependency Vulnerability Triage
+
+Status: classified; remediation not applied
+
+Audit target: `feature/d-04-next-actor-unify` at `6a0cd89`
+
+Evidence: `docs/security/mgx-sec-001-audit-evidence.json`
+
+## Result
+
+The historical deployment log reported 36 vulnerabilities on 2026-07-23 JST. That log retained only aggregate severity counts, not advisory identities. A reproducible audit of the current production branch now reports 20 vulnerable packages:
+
+| Classification | Packages | Current severity |
+|---|---:|---|
+| Runtime | 4 | 1 critical, 2 high, 1 moderate |
+| Build-only | 16 | 1 critical, 12 high, 2 moderate, 1 low |
+| Not applicable | 0 | — |
+
+The change from 36 to 20 is an audit-database/baseline reconciliation, not evidence that 16 named findings were fixed: the historical run did not preserve the machine-readable identities required to prove a one-to-one closure.
+
+## Runtime findings
+
+| Package | Path | Production relevance | Decision |
+|---|---|---|---|
+| `protobufjs` | `onnxruntime-web → protobufjs` | Browser ONNX model loading; current lock is 7.5.4 and includes critical code-generation advisories | Open a scoped lockfile upgrade PR first |
+| `@protobufjs/utf8` | `protobufjs → @protobufjs/utf8` | Same runtime chain | Remediate with `protobufjs` chain |
+| `react-router-dom` | direct dependency | Production SPA navigation | Upgrade in a scoped PR with navigation regression tests |
+| `react-router` | `react-router-dom → react-router` | Production SPA routing | Remediate with `react-router-dom` |
+
+Some React Router advisories are SSR/RSC-specific and are not exercised by this Vite SPA, but the package remains runtime-relevant because the same affected version also carries client-side redirect and route-matching advisories. It is therefore not classified as wholly non-applicable.
+
+## Build-only findings
+
+`@babel/core`, `ajv`, `brace-expansion`, `flatted`, `form-data`, `glob`, `js-yaml`, `minimatch`, `nanoid`, `picomatch`, `postcss`, `rollup`, `vite`, `vitest`, `ws`, and `yaml` occur only in the development, lint, test, or build graph under the current lockfile.
+
+These packages are not shipped as browser runtime dependencies. They still matter to developer and CI integrity, but they must not be presented as direct production-browser exposure. The critical `vitest` advisory requires the Vitest UI server to be listening; the repository uses `vitest run`, so it is build/test exposure rather than deployed runtime exposure.
+
+## Remediation order
+
+1. Upgrade the `onnxruntime-web`/`protobufjs` chain without changing model behavior.
+2. Upgrade `react-router-dom` and run route, navigation, deep-link, and redirect regression tests.
+3. Upgrade direct build tools (`vite`, `vitest`, `postcss`) in a separate PR.
+4. Refresh transitive build-only packages through their direct parents; do not use `npm audit fix --force`.
+5. Require build, Tier 1 tests, MGX safety tests, and production-branch deploy checks before promotion.
+
+## Residual risk
+
+Until the scoped runtime PRs land, the runtime graph retains one critical package-level finding in `protobufjs` and two high package-level findings in React Router. No dependency or deployed branch was modified during this classification.

--- a/docs/security/mgx-sec-001-audit-evidence.json
+++ b/docs/security/mgx-sec-001-audit-evidence.json
@@ -1,0 +1,48 @@
+{
+  "task_id": "MGX-SEC-001",
+  "captured_at": "2026-08-11T11:29:00+09:00",
+  "repository": "Koki-Minoda/badugi-app",
+  "audited_ref": "feature/d-04-next-actor-unify",
+  "audited_commit": "6a0cd89",
+  "commands": [
+    "npm audit --json",
+    "npm audit --omit=dev --json"
+  ],
+  "historical_baseline": {
+    "source_run": 29959098089,
+    "captured_at": "2026-07-23T06:25:15+09:00",
+    "counts": {"low": 2, "moderate": 11, "high": 21, "critical": 2, "total": 36},
+    "note": "The deploy log retained aggregate counts only; it did not retain machine-readable advisory identities."
+  },
+  "current_full_audit": {
+    "counts": {"low": 1, "moderate": 3, "high": 14, "critical": 2, "total": 20},
+    "packages": [
+      {"name": "@babel/core", "severity": "low", "classification": "build-only"},
+      {"name": "@protobufjs/utf8", "severity": "moderate", "classification": "runtime"},
+      {"name": "ajv", "severity": "moderate", "classification": "build-only"},
+      {"name": "brace-expansion", "severity": "high", "classification": "build-only"},
+      {"name": "flatted", "severity": "high", "classification": "build-only"},
+      {"name": "form-data", "severity": "high", "classification": "build-only"},
+      {"name": "glob", "severity": "high", "classification": "build-only"},
+      {"name": "js-yaml", "severity": "high", "classification": "build-only"},
+      {"name": "minimatch", "severity": "high", "classification": "build-only"},
+      {"name": "nanoid", "severity": "high", "classification": "build-only"},
+      {"name": "picomatch", "severity": "high", "classification": "build-only"},
+      {"name": "postcss", "severity": "high", "classification": "build-only"},
+      {"name": "protobufjs", "severity": "critical", "classification": "runtime"},
+      {"name": "react-router", "severity": "high", "classification": "runtime"},
+      {"name": "react-router-dom", "severity": "high", "classification": "runtime"},
+      {"name": "rollup", "severity": "high", "classification": "build-only"},
+      {"name": "vite", "severity": "high", "classification": "build-only"},
+      {"name": "vitest", "severity": "critical", "classification": "build-only"},
+      {"name": "ws", "severity": "high", "classification": "build-only"},
+      {"name": "yaml", "severity": "moderate", "classification": "build-only"}
+    ]
+  },
+  "current_production_omit_dev_audit": {
+    "counts": {"low": 0, "moderate": 1, "high": 2, "critical": 1, "total": 4},
+    "packages": ["@protobufjs/utf8", "protobufjs", "react-router", "react-router-dom"]
+  },
+  "classification_totals": {"runtime": 4, "build-only": 16, "not-applicable": 0},
+  "integrity_note": "No dependency versions or production deployment state were changed by this audit."
+}


### PR DESCRIPTION
## What changed
- preserve the historical 36-vulnerability deploy baseline
- add current machine-readable audit evidence for the production branch
- classify the reproducible findings as runtime or build-only
- define a scoped remediation order without changing dependencies or deployment state

## Key result
The historical run retained only aggregate counts. The current production-branch lockfile reproduces 20 vulnerable packages: 4 runtime and 16 build-only. The report records the reconciliation instead of falsely claiming one-to-one closure of the original 36.

## Validation
- `npm audit --json`
- `npm audit --omit=dev --json`
- JSON parsed with `jq`
- `git diff --check`

Refs #17. This classification PR does not close MGX-SEC-001; the scoped runtime remediation PRs and residual-risk decision remain open.