### PR TITLE
Fix production npm permissions during clean deploy

### DIFF
--- a/scripts/deploy/mgx-prod-01.sh
+++ b/scripts/deploy/mgx-prod-01.sh
@@ -110,7 +110,17 @@ git checkout "$GIT_BRANCH"
 git pull "$GIT_REMOTE" "$GIT_BRANCH"
 
 echo "[mgx-deploy] installing frontend dependencies"
-npm install --legacy-peer-deps
+NPM_CACHE_DIR="${NPM_CACHE_DIR:-/tmp/mgx-npm-cache-$(id -u)}"
+install -d -m 700 "$NPM_CACHE_DIR"
+
+# Older production runs created parts of node_modules as root. npm cannot
+# replace those files during a clean install, so normalize only this generated
+# dependency tree while leaving application files untouched.
+if [ -d "node_modules" ]; then
+  sudo chown -R "$(id -u):$(id -g)" node_modules
+fi
+
+npm ci --legacy-peer-deps --cache "$NPM_CACHE_DIR"
 
 echo "[mgx-deploy] building frontend"
 npm run build


### PR DESCRIPTION
## Cause
The first `main@53c0a85` deployment reached the VPS but failed in `npm install` because the legacy user cache and generated `node_modules` contained root-owned files (`EACCES`, exit 243).

## Fix
- use deterministic `npm ci --legacy-peer-deps`
- use a deploy-user-owned cache under `/tmp` instead of the contaminated home cache
- normalize ownership only for the generated `node_modules` tree before replacement

## Safety
Application source and persistent data ownership are not changed. `bash -n` and diff checks pass.