### PR TITLE
Clean generated dependencies with deploy-user permissions

### DIFF
--- a/scripts/deploy/mgx-prod-01.sh
+++ b/scripts/deploy/mgx-prod-01.sh
@@ -119,7 +119,8 @@ install -d -m 700 "$NPM_CACHE_DIR"
 if [ -d "node_modules" ]; then
   test "$APP_DIR" = "$(pwd)"
   test "$APP_DIR" != "/"
-  sudo rm -rf -- "$APP_DIR/node_modules"
+  sudo -n chown -R "$(id -u):$(id -g)" "$APP_DIR/node_modules"
+  rm -rf -- "$APP_DIR/node_modules"
 fi
 
 env npm_config_cache="$NPM_CACHE_DIR" npm ci --legacy-peer-deps


### PR DESCRIPTION
The VPS sudo policy permits ownership repair but not direct privileged removal. Normalize the generated dependency tree with non-interactive sudo, then remove it as the deploy user before deterministic `npm ci`. No persistent or source data is affected.