### PR TITLE
Avoid privileged dependency cleanup during deploy

### DIFF
--- a/scripts/deploy/mgx-prod-01.sh
+++ b/scripts/deploy/mgx-prod-01.sh
@@ -119,7 +119,6 @@ install -d -m 700 "$NPM_CACHE_DIR"
 if [ -d "node_modules" ]; then
   test "$APP_DIR" = "$(pwd)"
   test "$APP_DIR" != "/"
-  sudo -n chown -R "$(id -u):$(id -g)" "$APP_DIR/node_modules"
   rm -rf -- "$APP_DIR/node_modules"
 fi
 


### PR DESCRIPTION
The VPS sudo policy does not allow `chown` or `rm` non-interactively. The generated dependency tree was already normalized by the first remediation attempt, so remove it directly as the deploy user and recreate it with `npm ci`. This also prevents future root-owned dependency files because npm is never run through sudo.