### PR TITLE
test: lock Android landscape actions to the visual viewport

### DIFF
--- a/tests/e2e/mobile-tournament-landscape-action-buttons.spec.ts
+++ b/tests/e2e/mobile-tournament-landscape-action-buttons.spec.ts
@@ -8,8 +8,14 @@ const REPORT_PATH = path.resolve("reports/ui/mobile-tournament-landscape-action-
 const SCREENSHOT_DIR = path.resolve("reports/screenshots/mobile-tournament-landscape-action-buttons");
 
 const PWA_LANDSCAPE_VIEWPORTS = [
-  { name: "iphone-pwa-landscape-844x390", width: 844, height: 390 },
-  { name: "iphone-pwa-tight-landscape-844x360", width: 844, height: 360 },
+  { name: "iphone-pwa-landscape-844x390", width: 844, height: 390, platform: "ios" },
+  { name: "iphone-pwa-tight-landscape-844x360", width: 844, height: 360, platform: "ios" },
+  {
+    name: "pixel9-chrome-toolbar-landscape-869x303",
+    width: 869,
+    height: 303,
+    platform: "android",
+  },
 ] as const;
 
 const SANITY_VIEWPORTS = [
@@ -22,14 +28,19 @@ function ensureReportDirs() {
   fs.mkdirSync(SCREENSHOT_DIR, { recursive: true });
 }
 
-async function openPwaPage(browser: Browser, viewport: { width: number; height: number }) {
+async function openPwaPage(
+  browser: Browser,
+  viewport: { width: number; height: number; platform: "ios" | "android" },
+) {
+  const isAndroid = viewport.platform === "android";
   const context = await browser.newContext({
     viewport: { width: viewport.width, height: viewport.height },
     isMobile: true,
     hasTouch: true,
-    deviceScaleFactor: 3,
-    userAgent:
-      "Mozilla/5.0 (iPhone; CPU iPhone OS 17_5 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.5 Mobile/15E148 Safari/604.1",
+    deviceScaleFactor: isAndroid ? 2.625 : 3,
+    userAgent: isAndroid
+      ? "Mozilla/5.0 (Linux; Android 10; K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/151.0.0.0 Mobile Safari/537.36"
+      : "Mozilla/5.0 (iPhone; CPU iPhone OS 17_5 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.5 Mobile/15E148 Safari/604.1",
   });
   const page = await context.newPage();
   return { context, page };
@@ -76,6 +87,7 @@ async function assertButtonFullyUsable(page: Page, testId: string) {
   ).toBeGreaterThanOrEqual(0.9);
   expect(box!.x, `${testId} left should be inside viewport`).toBeGreaterThanOrEqual(0);
   expect(box!.x + box!.width, `${testId} right should be inside viewport`).toBeLessThanOrEqual(viewport.width + 1);
+  expect(box!.y, `${testId} top should be inside viewport`).toBeGreaterThanOrEqual(0);
   expect(box!.y + box!.height, `${testId} bottom should be inside viewport`).toBeLessThanOrEqual(viewport.height + 1);
   await locator.click({ trial: true, timeout: 1500 });
 }

--- a/tests/e2e/mobile-tournament-visual-viewport.spec.ts
+++ b/tests/e2e/mobile-tournament-visual-viewport.spec.ts
@@ -75,14 +75,17 @@ test.describe("mobile tournament visual viewport sizing", () => {
     const initial = await visualState(page);
     expectButtonsInside(initial);
 
-    await page.setViewportSize({ width: 844, height: 300 });
+    // Pixel 9 + Chrome 151 landscape with the browser toolbar visible exposes
+    // a 869x303 CSS-pixel visual viewport on the emulator. Keep this exact
+    // production geometry covered so off-screen controls cannot pass CI.
+    await page.setViewportSize({ width: 869, height: 303 });
     await page.waitForFunction(() => {
       const value = getComputedStyle(document.documentElement).getPropertyValue("--mgx-visual-vh");
-      return value.trim().startsWith("300");
+      return value.trim().startsWith("303");
     });
     const shrunk = await visualState(page);
     expectButtonsInside(shrunk);
-    const screenshotPath = path.join(SCREENSHOT_DIR, "badugi-landscape-shrunk-844x300.png");
+    const screenshotPath = path.join(SCREENSHOT_DIR, "badugi-pixel9-chrome-toolbar-869x303.png");
     rows.push({ status: "PASS", initial, shrunk, screenshotPath });
     await page.screenshot({ path: screenshotPath, fullPage: true });
   });


### PR DESCRIPTION
## Summary
- add the exact Pixel 9 / Chrome 151 toolbar-visible landscape viewport (869x303 CSS px)
- require every betting action to be fully contained on all four viewport edges
- retain portrait and iPhone landscape coverage

## Verification
- Pixel 9 Android Emulator, Chrome 151: Call button fully visible and activated with an ADB screen-coordinate tap; phase advanced BET → DRAW
- 7 targeted mobile viewport E2E tests passed
- lint passed
- production build passed
- Tier 1: 282 files, 1965 passed, 11 skipped