### PR TITLE
fix(ui): make landscape seats viewport responsive

### DIFF
--- a/src/ui/screens/layouts/GameLayoutBase.jsx
+++ b/src/ui/screens/layouts/GameLayoutBase.jsx
@@ -45,12 +45,12 @@ const MOBILE_LANDSCAPE_SEAT_GRID_AREA = {
 };
 
 const MOBILE_LANDSCAPE_SEAT_ALIGN_CLASS = {
-  0: "items-center justify-end pb-1",
-  1: "items-start justify-end pb-5",
-  2: "items-start justify-start pt-2",
-  3: "items-center justify-start pt-1",
-  4: "items-end justify-start pt-2",
-  5: "items-end justify-end pb-5",
+  0: "items-center justify-end pb-[clamp(2px,1.2dvh,6px)]",
+  1: "items-start justify-end pb-[clamp(6px,5dvh,20px)]",
+  2: "items-start justify-start pt-[clamp(4px,2.5dvh,10px)]",
+  3: "items-center justify-start pt-[clamp(2px,1.2dvh,6px)]",
+  4: "items-end justify-start pt-[clamp(4px,2.5dvh,10px)]",
+  5: "items-end justify-end pb-[clamp(6px,5dvh,20px)]",
 };
 
 const MOBILE_TABLE_GRID_STYLE = {

--- a/tests/e2e/helpers/core5TournamentLayoutHelper.ts
+++ b/tests/e2e/helpers/core5TournamentLayoutHelper.ts
@@ -17,9 +17,12 @@ import {
 export const TOURNAMENT_VIEWPORTS = [
   { name: "portrait-390x844", width: 390, height: 844, orientation: "portrait" },
   { name: "portrait-430x932", width: 430, height: 932, orientation: "portrait" },
+  { name: "compact-landscape-720x280", width: 720, height: 280, orientation: "landscape" },
   { name: "landscape-844x390", width: 844, height: 390, orientation: "landscape" },
   { name: "pixel9-chrome-869x303", width: 869, height: 303, orientation: "landscape" },
+  { name: "short-wide-932x280", width: 932, height: 280, orientation: "landscape" },
   { name: "landscape-932x430", width: 932, height: 430, orientation: "landscape" },
+  { name: "foldable-landscape-1180x540", width: 1180, height: 540, orientation: "landscape" },
 ] as const;
 
 export type TournamentViewport = (typeof TOURNAMENT_VIEWPORTS)[number];
@@ -148,6 +151,10 @@ function validateLandscapeSeatGeometry({
   const boxes = seatBoxes as NonNullable<Awaited<ReturnType<typeof visibleBox>>>[];
   const centers = boxes.map(centerOf);
   const tableCenter = centerOf(tableBox);
+  const normalized = centers.map((center) => ({
+    x: (center.x - tableBox.x) / tableBox.width,
+    y: (center.y - tableBox.y) / tableBox.height,
+  }));
 
   for (let index = 0; index < boxes.length; index += 1) {
     const box = boxes[index];
@@ -186,6 +193,21 @@ function validateLandscapeSeatGeometry({
     [0, 1, 5].every((index) => centers[index].y > tableCenter.y);
   if (!topOrderValid || !bottomOrderValid || !verticalArcValid) {
     issues.push({ priority: "P0", issue: "SEAT_RING_ORDER_INVALID", value: centers });
+  }
+
+  const relativeArcValid =
+    [2, 3, 4].every((index) => normalized[index].y < 0.4) &&
+    [0, 1, 5].every((index) => normalized[index].y > 0.6) &&
+    normalized[0].x > 0.35 && normalized[0].x < 0.65 &&
+    [1, 2].every((index) => normalized[index].x < 0.3) &&
+    [4, 5].every((index) => normalized[index].x > 0.7);
+  if (!relativeArcValid) {
+    issues.push({
+      priority: "P0",
+      issue: "SEAT_RING_RELATIVE_POSITION_INVALID",
+      message: "seat centers left their viewport-relative table bands",
+      value: normalized,
+    });
   }
 
   const pairToleranceX = tableBox.width * 0.08;

--- a/tests/e2e/mobile-tournament-landscape-action-buttons.spec.ts
+++ b/tests/e2e/mobile-tournament-landscape-action-buttons.spec.ts
@@ -8,12 +8,24 @@ const REPORT_PATH = path.resolve("reports/ui/mobile-tournament-landscape-action-
 const SCREENSHOT_DIR = path.resolve("reports/screenshots/mobile-tournament-landscape-action-buttons");
 
 const PWA_LANDSCAPE_VIEWPORTS = [
+  {
+    name: "compact-android-landscape-720x280",
+    width: 720,
+    height: 280,
+    platform: "android",
+  },
   { name: "iphone-pwa-landscape-844x390", width: 844, height: 390, platform: "ios" },
   { name: "iphone-pwa-tight-landscape-844x360", width: 844, height: 360, platform: "ios" },
   {
     name: "pixel9-chrome-toolbar-landscape-869x303",
     width: 869,
     height: 303,
+    platform: "android",
+  },
+  {
+    name: "foldable-android-landscape-1180x540",
+    width: 1180,
+    height: 540,
     platform: "android",
   },
 ] as const;


### PR DESCRIPTION
## Summary
- scale landscape seat arc offsets with dynamic viewport height instead of fixed spacing utilities
- validate seat positions with table-relative geometry bands
- extend layout QA from compact 720x280 through Pixel 9 to foldable 1180x540
- verify action controls at compact and foldable boundaries

## Validation
- npm run lint
- npm run build
- npm run test:tier1 (282 files, 1965 passed, 11 skipped)
- mobile tournament action matrix (7 passed)
- landscape geometry matrix: all 30 layouts had zero geometry issues; local AI model endpoint produced unrelated intermittent 503/WASM fallback console errors in the combined run