### PR TITLE
test(ci): stabilize stochastic strategy checks

### DIFF
--- a/scripts/run-core5-cpu-vs-cpu-sanity.js
+++ b/scripts/run-core5-cpu-vs-cpu-sanity.js
@@ -28,12 +28,13 @@ function parseArgs(argv) {
     seats: 6,
     mode: "cash",
     cpu: "heuristic",
+    seed: 20260826,
     outDir: "reports/ai",
   };
   for (const arg of argv.slice(2)) {
     const [rawKey, rawValue = "true"] = arg.replace(/^--/, "").split("=");
     if (rawKey in options) {
-      options[rawKey] = rawKey === "hands" || rawKey === "seats" ? Number(rawValue) : rawValue;
+      options[rawKey] = ["hands", "seats", "seed"].includes(rawKey) ? Number(rawValue) : rawValue;
     }
   }
   options.variantList = String(options.variants)
@@ -41,6 +42,17 @@ function parseArgs(argv) {
     .map((entry) => entry.trim())
     .filter(Boolean);
   return options;
+}
+
+function createSeededRandom(seed) {
+  let state = Number(seed) >>> 0;
+  return () => {
+    state = (state + 0x6d2b79f5) >>> 0;
+    let value = state;
+    value = Math.imul(value ^ (value >>> 15), value | 1);
+    value ^= value + Math.imul(value ^ (value >>> 7), value | 61);
+    return ((value ^ (value >>> 14)) >>> 0) / 4294967296;
+  };
 }
 
 function getSnapshot(controller, state) {
@@ -257,6 +269,9 @@ function simulateVariant({ variantId, hands, seats, mode, cpuMode, trace }) {
 
 export function runCore5CpuVsCpuSanity(options) {
   const originalLog = console.log;
+  const originalRandom = Math.random;
+  const seed = Number.isFinite(Number(options.seed)) ? Number(options.seed) : 20260826;
+  Math.random = createSeededRandom(seed);
   console.log = (...args) => {
     if (String(args[0] ?? "").startsWith("[DECK]")) return;
     originalLog(...args);
@@ -298,12 +313,14 @@ export function runCore5CpuVsCpuSanity(options) {
         seats: options.seats,
         mode: options.mode,
         cpu: options.cpu,
+        seed,
       },
       results,
       decisionSummary: trace.summarize(),
     };
     return { trace, summary };
   } finally {
+    Math.random = originalRandom;
     console.log = originalLog;
   }
 }

--- a/src/ai/__tests__/core5CpuStrategySanity.test.js
+++ b/src/ai/__tests__/core5CpuStrategySanity.test.js
@@ -9,6 +9,7 @@ describe("Core5 CPU strategy sanity", () => {
       seats: 6,
       mode: "cash",
       cpu: "heuristic",
+      seed: 20260826,
     });
 
     for (const result of summary.results) {

--- a/src/ui/screens/__tests__/ChinesePokerGameScreen.test.jsx
+++ b/src/ui/screens/__tests__/ChinesePokerGameScreen.test.jsx
@@ -27,7 +27,7 @@ describe("ChinesePokerGameScreen", () => {
     fireEvent.click(screen.getByTestId("chinese-next-hand"));
     expect(screen.getByText(/Hand #2/)).toBeTruthy();
     expect(screen.queryByTestId("chinese-results")).toBeNull();
-  });
+  }, 10000);
 
   it("returns to game selector through the back action", () => {
     const onBack = vi.fn();


### PR DESCRIPTION
## Summary
- seed the Core5 CPU sanity runner and restore global randomness after each synchronous run
- record the seed in generated summaries for reproduction
- give the synchronous Chinese Poker interaction test headroom under shared CI load

## Why
The release gate exposed two unrelated flaky failures on the same main commit: one 5s UI-test timeout and one random simulation with zero raises. This makes both checks repeatable without weakening their assertions.

## Validation
- focused tests: 5 passed
- deterministic same-seed summary comparison: identical
- npm run lint
- Tier1: 282 files, 1965 passed, 11 skipped