### PR TITLE
Show authenticated hero name and prepare Windows RL training

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -60,7 +60,9 @@ desktop.ini
 
 # add this to .gitignore
 runs/
-structure.txt# RL artifacts
+structure.txt
+
+# RL artifacts
 rl/models/*
 !rl/models/.gitkeep
 rl/evaluations/*

--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
     "ai:evaluate-draw-selfplay": "node scripts/runPythonTool.mjs src/rl/training/evaluate_selfplay_draw.py",
     "ai:gate-draw-model": "node scripts/runPythonTool.mjs src/rl/training/gate_draw_model.py",
     "ai:train-badugi": "node scripts/runPythonTool.mjs src/rl/training/train_dqn.py",
+    "ai:train-badugi-sixmax": "node scripts/runPythonTool.mjs src/rl/training/train_sixmax_selfplay_badugi_dqn.py",
     "ai:export-badugi-onnx": "node scripts/runPythonTool.mjs src/rl/training/export_badugi_dqn_onnx.py",
     "ai:evaluate-badugi-onnx": "node scripts/runPythonTool.mjs src/rl/training/evaluate_badugi_onnx.py",
     "ai:gate-badugi-model": "node scripts/runPythonTool.mjs src/rl/training/gate_badugi_model.py",

--- a/scripts/runPythonTool.mjs
+++ b/scripts/runPythonTool.mjs
@@ -8,7 +8,11 @@ if (!scriptPath) {
   process.exit(2);
 }
 
-const python = existsSync(".venv/bin/python") ? ".venv/bin/python" : "python3";
+const pythonCandidates = process.platform === "win32"
+  ? [".venv-rl/Scripts/python.exe", ".venv/Scripts/python.exe"]
+  : [".venv/bin/python"];
+const python = pythonCandidates.find((candidate) => existsSync(candidate))
+  ?? (process.platform === "win32" ? "python" : "python3");
 const result = spawnSync(python, [scriptPath, ...args], {
   stdio: "inherit",
   env: process.env,

--- a/scripts/windows-badugi-rl.ps1
+++ b/scripts/windows-badugi-rl.ps1
@@ -1,0 +1,130 @@
+[CmdletBinding()]
+param(
+    [ValidateSet("Diagnose", "Setup", "Smoke", "Train", "Resume")]
+    [string]$Mode = "Diagnose",
+    [ValidateSet("auto", "cpu", "cuda")]
+    [string]$Device = "auto",
+    [int]$Episodes = 100000,
+    [int]$SaveInterval = 10000,
+    [int]$LogInterval = 1000,
+    [string]$OutputDir = "rl/models/badugi_sixmax_windows",
+    [string]$Checkpoint = "rl/models/badugi_sixmax_foldmargin_100k_from_raiseev_fix/badugi_sixmax_dqn_latest.pt",
+    [string]$OpponentCheckpoint = "",
+    [string]$TorchIndexUrl = ""
+)
+
+$ErrorActionPreference = "Stop"
+$repoRoot = Split-Path -Parent $PSScriptRoot
+$venvPython = Join-Path $repoRoot ".venv-rl\Scripts\python.exe"
+$trainer = Join-Path $repoRoot "src\rl\training\train_sixmax_selfplay_badugi_dqn.py"
+
+function Resolve-RepoPath([string]$PathValue) {
+    if ([System.IO.Path]::IsPathRooted($PathValue)) { return $PathValue }
+    return Join-Path $repoRoot $PathValue
+}
+
+function Require-Python {
+    if (-not (Test-Path $venvPython)) {
+        throw "RL environment is missing. Run: .\scripts\windows-badugi-rl.ps1 -Mode Setup"
+    }
+}
+
+function Show-Diagnostics {
+    Write-Host "Repository: $repoRoot"
+    Write-Host "Virtual environment: $venvPython"
+    if (-not (Test-Path $venvPython)) {
+        Write-Host "Python environment: NOT SET UP"
+        return
+    }
+    & $venvPython -c "import platform, torch; print('Python:', platform.python_version()); print('PyTorch:', torch.__version__); print('CUDA available:', torch.cuda.is_available()); print('CUDA runtime:', torch.version.cuda); print('GPU:', torch.cuda.get_device_name(0) if torch.cuda.is_available() else 'none')"
+    if ($LASTEXITCODE -ne 0) { throw "Python/PyTorch diagnostics failed." }
+}
+
+if ($Mode -eq "Setup") {
+    $basePython = Get-Command py -ErrorAction SilentlyContinue
+    if ($null -ne $basePython) {
+        & py -3 -m venv (Join-Path $repoRoot ".venv-rl")
+    } else {
+        $python = Get-Command python -ErrorAction SilentlyContinue
+        if ($null -eq $python) { throw "Python 3.11+ is required." }
+        & python -m venv (Join-Path $repoRoot ".venv-rl")
+    }
+    Require-Python
+    & $venvPython -m pip install --upgrade pip
+    if ($LASTEXITCODE -ne 0) { throw "pip upgrade failed." }
+    if ($TorchIndexUrl) {
+        & $venvPython -m pip install torch --index-url $TorchIndexUrl
+        if ($LASTEXITCODE -ne 0) { throw "PyTorch installation failed." }
+    }
+    & $venvPython -m pip install -r (Join-Path $repoRoot "src\rl\requirements.txt")
+    if ($LASTEXITCODE -ne 0) { throw "RL dependency setup failed." }
+    Show-Diagnostics
+    Write-Host "Setup complete. Next: .\scripts\windows-badugi-rl.ps1 -Mode Smoke"
+    exit 0
+}
+
+if ($Mode -eq "Diagnose") {
+    Show-Diagnostics
+    exit 0
+}
+
+Require-Python
+$cudaAvailable = (& $venvPython -c "import torch; print('true' if torch.cuda.is_available() else 'false')").Trim() -eq "true"
+if ($Device -eq "cuda" -and -not $cudaAvailable) {
+    throw "CUDA was requested but PyTorch cannot see the GPU. Run Diagnose and install the matching official PyTorch CUDA wheel."
+}
+$resolvedDevice = if ($Device -eq "auto") { if ($cudaAvailable) { "cuda" } else { "cpu" } } else { $Device }
+
+$resolvedOutput = Resolve-RepoPath $OutputDir
+$resolvedCheckpoint = Resolve-RepoPath $Checkpoint
+$resolvedOpponent = if ($OpponentCheckpoint) { Resolve-RepoPath $OpponentCheckpoint } else { "" }
+
+if ($Mode -eq "Smoke") {
+    $Episodes = 4
+    $SaveInterval = 2
+    $LogInterval = 1
+    $resolvedOutput = Join-Path $env:TEMP "mgx-badugi-sixmax-smoke"
+    $trainArgs = @(
+        $trainer, "--episodes", $Episodes, "--output-dir", $resolvedOutput,
+        "--save-interval", $SaveInterval, "--log-interval", $LogInterval,
+        "--teacher-warmup-episodes", 0, "--max-steps-per-episode", 8,
+        "--warmup-steps", 1, "--train-every-steps", 1,
+        "--batch-size", 2, "--buffer-capacity", 64, "--device", $resolvedDevice
+    )
+} else {
+    if ($Episodes -le 0 -or $SaveInterval -le 0 -or $LogInterval -le 0) {
+        throw "Episodes, SaveInterval, and LogInterval must be positive."
+    }
+    $trainArgs = @(
+        $trainer, "--episodes", $Episodes, "--output-dir", $resolvedOutput,
+        "--save-interval", $SaveInterval, "--log-interval", $LogInterval,
+        "--device", $resolvedDevice,
+        "--batch-size", 128, "--buffer-capacity", 300000
+    )
+    if ($Mode -eq "Resume") {
+        if (-not (Test-Path $resolvedCheckpoint)) {
+            throw "Checkpoint not found: $resolvedCheckpoint"
+        }
+        $trainArgs += @(
+            "--pretrained", $resolvedCheckpoint,
+            "--resume-continuation"
+        )
+    }
+    if ($resolvedOpponent) {
+        if (-not (Test-Path $resolvedOpponent)) { throw "Opponent checkpoint not found: $resolvedOpponent" }
+        $trainArgs += @("--pretrained-opponent", $resolvedOpponent)
+    }
+}
+
+New-Item -ItemType Directory -Force -Path $resolvedOutput | Out-Null
+$logPath = Join-Path $resolvedOutput ("training-{0}.log" -f (Get-Date -Format "yyyyMMdd-HHmmss"))
+Write-Host "Mode=$Mode Device=$resolvedDevice Episodes=$Episodes"
+Write-Host "Output=$resolvedOutput"
+Write-Host "Log=$logPath"
+Push-Location $repoRoot
+try {
+    & $venvPython @trainArgs 2>&1 | Tee-Object -FilePath $logPath
+    if ($LASTEXITCODE -ne 0) { throw "Training command failed with exit code $LASTEXITCODE." }
+} finally {
+    Pop-Location
+}

--- a/src/rl/README.md
+++ b/src/rl/README.md
@@ -101,6 +101,44 @@ npm run ai:gate-badugi-model -- \
 ```
 
 Use `--device cuda` only when the host has a compatible GPU setup.
+
+## Windows GPU training
+
+The PowerShell launcher is safe by default: without arguments it only reports
+the local Python, PyTorch, CUDA, and GPU status. From PowerShell in
+`C:\projects\badugi-app`:
+
+```powershell
+.\scripts\windows-badugi-rl.ps1 -Mode Setup
+.\scripts\windows-badugi-rl.ps1 -Mode Smoke
+```
+
+`Setup` creates the isolated `.venv-rl` environment. If the default PyTorch
+package cannot see the NVIDIA GPU, obtain the current Windows CUDA wheel index
+URL from the official PyTorch installer and pass it explicitly with
+`-TorchIndexUrl`. The launcher refuses `-Device cuda` when CUDA is unavailable.
+`Train` starts a fresh run; `Resume` is the only mode that loads `-Checkpoint`.
+
+After the smoke run succeeds, start an explicit 100k continuation from the
+tracked 50k checkpoint:
+
+```powershell
+.\scripts\windows-badugi-rl.ps1 `
+  -Mode Resume `
+  -Device auto `
+  -Episodes 100000 `
+  -SaveInterval 10000 `
+  -OutputDir rl/models/badugi_sixmax_windows_100k
+```
+
+The default checkpoint is
+`rl/models/badugi_sixmax_foldmargin_100k_from_raiseev_fix/badugi_sixmax_dqn_latest.pt`.
+`Resume` loads its weights, uses continuation epsilon decay, and skips teacher
+warm-up/imitation. Checkpoints, the latest summary JSON, and a timestamped log
+are kept under the output directory. This is a continuation run, not a
+bit-for-bit process resume: replay-buffer contents and the previous episode
+counter are not stored in the checkpoint.
+
 Do not promote a checkpoint to Pro / Iron / WorldMaster unless it was trained
 after the latest `BadugiEnv` reward/showdown fixes, has positive or clearly
 tier-appropriate avgReward across multiple opponent profiles, and passes ONNX

--- a/src/rl/__tests__/test_badugi_selfplay_readiness.py
+++ b/src/rl/__tests__/test_badugi_selfplay_readiness.py
@@ -19,6 +19,7 @@ from rl.training.train_sixmax_selfplay_badugi_dqn import (
     _load_initial_opponent_agent,
     _margin_batch_size,
     _maybe_imitation_update,
+    parse_args as parse_sixmax_args,
     train_sixmax_selfplay_badugi_dqn,
 )
 from rl.training.sixmax_action_telemetry import SixMaxActionTelemetry
@@ -63,6 +64,26 @@ def test_sixmax_trainer_defaults_counter_vpip_plateau():
     assert _margin_batch_size(cfg) == 32
     assert cfg.call_margin == pytest.approx(0.20)
     assert cfg.call_margin_weight == pytest.approx(0.40)
+
+
+def test_sixmax_cli_exposes_windows_training_controls():
+    args = parse_sixmax_args([
+        "--episodes", "12",
+        "--max-steps-per-episode", "7",
+        "--warmup-steps", "4",
+        "--train-every-steps", "2",
+        "--learning-rate", "0.0002",
+        "--imitation-pretrain-steps", "3",
+        "--expert-replay-ratio", "0.2",
+    ])
+
+    assert args.episodes == 12
+    assert args.max_steps_per_episode == 7
+    assert args.warmup_steps == 4
+    assert args.train_every_steps == 2
+    assert args.learning_rate == pytest.approx(0.0002)
+    assert args.imitation_pretrain_steps == 3
+    assert args.expert_replay_ratio == pytest.approx(0.2)
 
 
 def test_sixmax_fold_margin_batch_size_scales_with_config_batch_size():

--- a/src/rl/training/train_sixmax_selfplay_badugi_dqn.py
+++ b/src/rl/training/train_sixmax_selfplay_badugi_dqn.py
@@ -841,6 +841,12 @@ def parse_args(argv: list[str] | None = None):
     parser.add_argument("--hidden-dim", type=int, default=SixMaxSelfPlayConfig.hidden_dim)
     parser.add_argument("--batch-size", type=int, default=SixMaxSelfPlayConfig.batch_size)
     parser.add_argument("--buffer-capacity", type=int, default=SixMaxSelfPlayConfig.buffer_capacity)
+    parser.add_argument("--max-steps-per-episode", type=int, default=SixMaxSelfPlayConfig.max_steps_per_episode)
+    parser.add_argument("--warmup-steps", type=int, default=SixMaxSelfPlayConfig.warmup_steps)
+    parser.add_argument("--train-every-steps", type=int, default=SixMaxSelfPlayConfig.train_every_steps)
+    parser.add_argument("--learning-rate", type=float, default=SixMaxSelfPlayConfig.learning_rate)
+    parser.add_argument("--imitation-pretrain-steps", type=int, default=SixMaxSelfPlayConfig.imitation_pretrain_steps)
+    parser.add_argument("--expert-replay-ratio", type=float, default=SixMaxSelfPlayConfig.expert_replay_ratio)
     parser.add_argument("--teacher-warmup-episodes", type=int, default=None)
     parser.add_argument("--resume-continuation", action="store_true")
     parser.add_argument("--resume-epsilon", type=float, default=SixMaxSelfPlayConfig.resume_epsilon)
@@ -874,6 +880,12 @@ if __name__ == "__main__":
         hidden_dim=args.hidden_dim,
         batch_size=args.batch_size,
         buffer_capacity=args.buffer_capacity,
+        max_steps_per_episode=args.max_steps_per_episode,
+        warmup_steps=args.warmup_steps,
+        train_every_steps=args.train_every_steps,
+        learning_rate=args.learning_rate,
+        imitation_pretrain_steps=args.imitation_pretrain_steps,
+        expert_replay_ratio=args.expert_replay_ratio,
         teacher_warmup_episodes=args.teacher_warmup_episodes,
         resume_continuation=args.resume_continuation,
         resume_epsilon=args.resume_epsilon,

--- a/src/ui/App.jsx
+++ b/src/ui/App.jsx
@@ -150,7 +150,10 @@ import {
   readPersistedHandHistory,
 } from "./utils/persistedHandHistory.js";
 import { useLocation, useNavigate } from "react-router-dom";
-import { loadTitleSettings } from "./utils/titleSettings";
+import {
+  loadTitleSettings,
+  resolveHeroPlayerName,
+} from "./utils/titleSettings";
 import { useRatingState } from "./hooks/useRatingState.js";
 import { summarizeAiDecisionLog } from "./utils/aiDecisionLog.js";
 import {
@@ -536,6 +539,7 @@ export default function App() {
   const initialModeRef = useRef(getRequestedModeFromURL());
   const authUserIdRef = useRef(null);
   const [authUserId, setAuthUserId] = useState(null);
+  const [authUsername, setAuthUsername] = useState(null);
   const [authToken, setAuthToken] = useState(null);
   const [authTokenType, setAuthTokenType] = useState(null);
   const [mode, setMode] = useState(initialModeRef.current);
@@ -816,11 +820,11 @@ export default function App() {
   const [titleSettings, setTitleSettings] = useState(() => loadTitleSettings());
   const heroProfile = useMemo(
     () => ({
-      name: titleSettings.playerName?.trim() || "You",
+      name: resolveHeroPlayerName(titleSettings.playerName, authUsername),
       titleBadge: titleSettings.playerTitle?.trim() || "",
       avatar: titleSettings.avatar || "default_avatar",
     }),
-    [titleSettings],
+    [authUsername, titleSettings],
   );
   const buildPlayersFromSeatTypes = useCallback(
     (seatConfig, stackValue = DEFAULT_STARTING_STACK, profile = heroProfile) =>
@@ -8642,7 +8646,7 @@ export default function App() {
           seat,
           name:
             seat === 0
-              ? "You"
+              ? (heroProfile?.name ?? "You")
               : (["Sora", "Mina", "Ren", "Hana", "Jun"][seat - 1] ??
                 `CPU ${seat + 1}`),
           tournamentPlayerId:
@@ -12947,6 +12951,7 @@ export default function App() {
   function handleAuthStateChange(state) {
     authUserIdRef.current = state?.user?.id ?? null;
     setAuthUserId(state?.user?.id ?? null);
+    setAuthUsername(state?.user?.username ?? null);
     setAuthToken(state?.accessToken ?? null);
     setAuthTokenType(state?.tokenType ?? null);
     if (typeof state?.isAuthenticated === "boolean") {

--- a/src/ui/components/Player.jsx
+++ b/src/ui/components/Player.jsx
@@ -673,6 +673,19 @@ export default function Player({
             {drawBadgeLabel}
           </div>
         )}
+        {mobileHeroCardOnly && (
+          <div className="relative z-10 flex min-w-0 items-center justify-center gap-1 leading-none text-white">
+            <span
+              data-testid={`seat-${seatIndex}-name`}
+              className="max-w-full truncate font-semibold"
+              title={player.name}
+              style={{ fontSize: "var(--player-name-size, 12px)" }}
+            >
+              {player.name}
+            </span>
+            {index === dealerIdx && <StatusPill label="D" tone="yellow" />}
+          </div>
+        )}
         {!mobileHeroCardOnly && (
           <div
             className={`relative z-10 flex items-start justify-between ${isDrawTableMobileLayout ? "gap-1" : "gap-2"}`}
@@ -697,7 +710,9 @@ export default function Player({
                     </span>
                   )}
                   <span
+                    data-testid={`seat-${seatIndex}-name`}
                     className="truncate"
+                    title={player.name}
                     style={{
                       fontSize: "var(--player-name-size, 14px)",
                       maxWidth: "var(--player-name-maxw, 150px)",

--- a/src/ui/components/__tests__/Player.test.jsx
+++ b/src/ui/components/__tests__/Player.test.jsx
@@ -18,6 +18,26 @@ describe("Player", () => {
     cleanup();
   });
 
+  test("keeps the hero player name visible in the mobile card-only layout", () => {
+    render(
+      <Player
+        player={{ ...basePlayer, name: "Koki" }}
+        index={0}
+        selfIndex={0}
+        turn={0}
+        dealerIdx={0}
+        phase="BET"
+        compact
+        mobileHeroCardOnly
+      />,
+    );
+
+    expect(screen.getByTestId("seat-0-name").textContent).toBe("Koki");
+    expect(screen.getByTestId("seat-0-name").getAttribute("title")).toBe(
+      "Koki",
+    );
+  });
+
   test("renders character avatar images and falls back to initials if the image is missing", () => {
     render(
       <Player

--- a/src/ui/utils/__tests__/titleSettings.test.js
+++ b/src/ui/utils/__tests__/titleSettings.test.js
@@ -1,0 +1,39 @@
+import { afterEach, describe, expect, test } from "vitest";
+import {
+  loadTitleSettings,
+  resolveHeroPlayerName,
+} from "../titleSettings.js";
+
+describe("resolveHeroPlayerName", () => {
+  afterEach(() => {
+    window.localStorage.clear();
+  });
+
+  test("uses the authenticated username when the local name is still the default placeholder", () => {
+    expect(resolveHeroPlayerName("You", "Koki")).toBe("Koki");
+  });
+
+  test("keeps an explicitly configured player name ahead of the account username", () => {
+    expect(resolveHeroPlayerName("Midnight Badugi", "Koki")).toBe(
+      "Midnight Badugi",
+    );
+  });
+
+  test("does not let a previously persisted default You override the authenticated username", () => {
+    window.localStorage.setItem(
+      "badugi.titleSettings",
+      JSON.stringify({ playerName: "You" }),
+    );
+
+    expect(
+      resolveHeroPlayerName(loadTitleSettings().playerName, "Koki"),
+    ).toBe("Koki");
+  });
+
+  test("falls back safely when profile values are missing or whitespace", () => {
+    expect(resolveHeroPlayerName("   ", "  account-player  ")).toBe(
+      "account-player",
+    );
+    expect(resolveHeroPlayerName(null, null)).toBe("You");
+  });
+});

--- a/src/ui/utils/titleSettings.js
+++ b/src/ui/utils/titleSettings.js
@@ -65,3 +65,19 @@ export function resetTitleSettings() {
 export function getDefaultTitleSettings() {
   return { ...DEFAULT_SETTINGS };
 }
+
+export function resolveHeroPlayerName(playerName, authenticatedUsername) {
+  const configuredName =
+    typeof playerName === "string" ? playerName.trim() : "";
+  const accountName =
+    typeof authenticatedUsername === "string"
+      ? authenticatedUsername.trim()
+      : "";
+
+  // The shipped "You" value is a placeholder, not a deliberate profile
+  // override. Once authentication is hydrated, show the account identity.
+  if (configuredName && configuredName !== DEFAULT_SETTINGS.playerName) {
+    return configuredName;
+  }
+  return accountName || configuredName || DEFAULT_SETTINGS.playerName;
+}

--- a/tests/e2e/mobile-tournament-landscape-action-buttons.spec.ts
+++ b/tests/e2e/mobile-tournament-landscape-action-buttons.spec.ts
@@ -66,6 +66,19 @@ async function openFixture(page: Page, variantId: string) {
   await waitForE2EDriver(page);
   await invokeE2E(page, "setupMobileTournamentHeroActionFixtureForTest", { variantId });
   await expect(page.getByTestId("decision-panel")).toBeVisible({ timeout: 10000 });
+  const authenticatedUsername = await page.evaluate(() => {
+    const raw = window.localStorage.getItem("mgx_auth");
+    if (!raw) return null;
+    try {
+      return JSON.parse(raw)?.user?.username ?? null;
+    } catch {
+      return null;
+    }
+  });
+  expect(authenticatedUsername, "authenticated username should be available").toBeTruthy();
+  await expect(page.getByTestId("seat-0-name")).toHaveText(
+    String(authenticatedUsername),
+  );
 }
 
 async function boxFor(locator: Locator) {


### PR DESCRIPTION
## Summary
- show the authenticated username at the hero seat while preserving explicit custom player names
- add responsive hero-name coverage to the mobile tournament QA matrix
- add a guarded Windows PowerShell workflow for Badugi six-max smoke, fresh training, and checkpoint continuation
- expose the trainer controls needed for safe Windows runs and detect Windows virtual environments

## Validation
- Tier 1: 283 files, 1,970 passed, 11 skipped
- focused UI unit tests: 25/25
- mobile tournament authenticated-name E2E: 7/7
- responsive landscape matrix: 30/30
- portrait/card layout: 19/19
- production build: pass
- RL readiness: 16/16
- fresh CPU 4-episode smoke: pass
- 50k-checkpoint continuation CPU 2-episode smoke: pass

## Windows status
The launcher and continuation path are ready, but the configured Windows host is currently unreachable on the local network. No long-running training has been started.