### PR TITLE
Fix Windows RL checkpoint startup

### DIFF
--- a/scripts/windows-badugi-rl.ps1
+++ b/scripts/windows-badugi-rl.ps1
@@ -123,8 +123,18 @@ Write-Host "Output=$resolvedOutput"
 Write-Host "Log=$logPath"
 Push-Location $repoRoot
 try {
-    & $venvPython @trainArgs 2>&1 | Tee-Object -FilePath $logPath
-    if ($LASTEXITCODE -ne 0) { throw "Training command failed with exit code $LASTEXITCODE." }
+    # Windows PowerShell 5 wraps native stderr as ErrorRecord objects. Keep
+    # warnings in the combined log without letting ErrorActionPreference=Stop
+    # abort before the native exit code can be checked.
+    $previousErrorActionPreference = $ErrorActionPreference
+    $ErrorActionPreference = "Continue"
+    try {
+        & $venvPython @trainArgs 2>&1 | Tee-Object -FilePath $logPath
+        $trainingExitCode = $LASTEXITCODE
+    } finally {
+        $ErrorActionPreference = $previousErrorActionPreference
+    }
+    if ($trainingExitCode -ne 0) { throw "Training command failed with exit code $trainingExitCode." }
 } finally {
     Pop-Location
 }

--- a/scripts/windows-badugi-rl.ps1
+++ b/scripts/windows-badugi-rl.ps1
@@ -123,6 +123,10 @@ Write-Host "Output=$resolvedOutput"
 Write-Host "Log=$logPath"
 Push-Location $repoRoot
 try {
+    # Keep trainer telemetry portable across Japanese Windows PowerShell,
+    # whose redirected native-process output otherwise defaults to CP932.
+    $env:PYTHONUTF8 = "1"
+    $env:PYTHONIOENCODING = "utf-8"
     # Windows PowerShell 5 wraps native stderr as ErrorRecord objects. Keep
     # warnings in the combined log without letting ErrorActionPreference=Stop
     # abort before the native exit code can be checked.

--- a/scripts/windows-badugi-rl.ps1
+++ b/scripts/windows-badugi-rl.ps1
@@ -127,6 +127,7 @@ try {
     # whose redirected native-process output otherwise defaults to CP932.
     $env:PYTHONUTF8 = "1"
     $env:PYTHONIOENCODING = "utf-8"
+    $env:PYTHONUNBUFFERED = "1"
     # Windows PowerShell 5 wraps native stderr as ErrorRecord objects. Keep
     # warnings in the combined log without letting ErrorActionPreference=Stop
     # abort before the native exit code can be checked.

--- a/src/rl/agents/dqn_agent.py
+++ b/src/rl/agents/dqn_agent.py
@@ -235,7 +235,7 @@ class DQNAgent:
     @classmethod
     def load(cls, path: str, device: torch.device | str = "cpu") -> "DQNAgent":
         try:
-            payload = torch.load(path, map_location=device)
+            payload = torch.load(path, map_location=device, weights_only=True)
         except Exception:
             # Project-generated checkpoints include small Python metadata
             # alongside tensor weights. Only use this fallback for trusted local


### PR DESCRIPTION
## Summary
- load trusted tensor checkpoints with the safe weights-only path first
- keep native stderr warnings in Windows PowerShell logs without treating them as process failures
- continue to fail closed on a non-zero trainer exit code

## Evidence
- Windows CPU fresh Smoke: 4 episodes passed
- Windows PyTorch 2.5.1+cpu import passed
- regression reproduced with checkpoint Resume before this fix
- Resume recheck will run on the Windows node from this PR head