### PR TITLE
feat(review): ground tournament feedback v2

### DIFF
--- a/src/ui/components/TournamentResultOverlay.jsx
+++ b/src/ui/components/TournamentResultOverlay.jsx
@@ -14,7 +14,7 @@ const TOURNAMENT_REVIEW_STATUS_COPY = {
   },
   complete: {
     label: "レビュー完了",
-    body: "保存済みレビューを表示しています。",
+    body: "根拠を構造化できた内容のみ採用し、ローカルレビューも保持しています。",
   },
   insufficient_logs: {
     label: "簡易レビューのみ",
@@ -25,8 +25,8 @@ const TOURNAMENT_REVIEW_STATUS_COPY = {
     body: "ログインすると詳細AIレビューを保存できます。",
   },
   error: {
-    label: "レビュー未作成",
-    body: "レビューを作成できませんでした。",
+    label: "ローカルレビュー",
+    body: "AIレビューを取得できなかったため、端末内の履歴から振り返ります。",
   },
 };
 
@@ -50,6 +50,51 @@ function getVariantLabel(review) {
   return variants[0] ?? review?.variantId ?? "Unknown";
 }
 
+function normalizeReviewItems(items = []) {
+  return (Array.isArray(items) ? items : []).map((item) =>
+    typeof item === "string"
+      ? { text: item, evidence: [], caveat: null }
+      : {
+          text: item?.text ?? "",
+          evidence: Array.isArray(item?.evidence) ? item.evidence : [],
+          caveat: item?.caveat ?? null,
+        },
+  ).filter((item) => item.text);
+}
+
+function formatEvidence(entry = {}) {
+  const handId = entry.handId ?? "--";
+  const range = entry.actionSeqRange;
+  if (!range?.start) return `Hand ${handId}`;
+  const seq = range.end && range.end !== range.start
+    ? `${range.start}-${range.end}`
+    : range.start;
+  return `Hand ${handId} · action ${seq}`;
+}
+
+function ReviewItemList({ items, emptyText }) {
+  if (!items.length) {
+    return <p className="mt-1 text-xs text-slate-400">{emptyText}</p>;
+  }
+  return (
+    <ul className="mt-1 space-y-2 text-xs text-slate-200">
+      {items.map((item, index) => (
+        <li key={`${item.text}:${index}`}>
+          <p>{item.text}</p>
+          {item.evidence.length ? (
+            <p className="mt-0.5 text-[10px] text-sky-200">
+              根拠: {item.evidence.map(formatEvidence).join(" / ")}
+            </p>
+          ) : null}
+          {item.caveat ? (
+            <p className="mt-0.5 text-[10px] text-slate-400">注記: {item.caveat}</p>
+          ) : null}
+        </li>
+      ))}
+    </ul>
+  );
+}
+
 function buildReviewView(review) {
   const result = review?.result ?? {};
   const totalHands =
@@ -63,7 +108,17 @@ function buildReviewView(review) {
   const improvementItems = Array.isArray(review?.nextImprovements?.items)
     ? review.nextImprovements.items.slice(0, 2)
     : [];
-  const response = review?.aiFeedback?.response ?? null;
+  const summary = review?.reviewSummary ?? {};
+  const facts = normalizeReviewItems(summary.facts).slice(0, 4);
+  const interpretations = normalizeReviewItems(
+    summary.interpretations ?? [
+      ...(summary.goodPoints ?? []),
+      ...(summary.improvementPoints ?? []),
+    ],
+  ).slice(0, 4);
+  const nextActions = normalizeReviewItems(
+    summary.nextActions ?? improvementItems,
+  ).slice(0, 3);
   return {
     status,
     statusCopy: TOURNAMENT_REVIEW_STATUS_COPY[status],
@@ -73,13 +128,16 @@ function buildReviewView(review) {
     variantLabel: getVariantLabel(review),
     keyHands,
     improvementItems,
-    completeText: response?.adviceJa ?? response?.summaryJa ?? response?.summary ?? null,
+    facts,
+    interpretations,
+    nextActions,
+    causalDisclaimer: summary.causalDisclaimer ?? null,
   };
 }
 
 function TournamentReviewSection({ tournamentReview, onOpenReviewReplay }) {
   const view = buildReviewView(tournamentReview);
-  const showReviewLists = view.status === "summary" || view.status === "complete";
+  const showReviewLists = Boolean(tournamentReview);
   return (
     <section
       className="rounded-2xl border border-emerald-300/20 bg-black/25 px-4 py-3 text-sm text-slate-100"
@@ -120,7 +178,7 @@ function TournamentReviewSection({ tournamentReview, onOpenReviewReplay }) {
       ) : null}
       {view.status === "error" ? (
         <p className="mt-3 rounded-xl bg-red-500/10 px-3 py-2 text-xs text-red-100">
-          レビューを作成できませんでした。順位と賞金結果は保存済みです。
+          AIレビューは取得できませんでした。以下のローカルレビューは引き続き利用できます。
         </p>
       ) : null}
       {view.status === "insufficient_logs" ? (
@@ -134,28 +192,41 @@ function TournamentReviewSection({ tournamentReview, onOpenReviewReplay }) {
         </p>
       ) : null}
       {showReviewLists ? (
-        <div className="mt-3 grid gap-3 sm:grid-cols-3">
-          <div className="rounded-xl bg-white/5 px-3 py-2">
-            <p className="text-[11px] font-semibold uppercase tracking-[0.18em] text-emerald-200">
-              良かった点
-            </p>
-            <p className="mt-1 text-xs text-slate-200">
-              {view.completeText ?? "入賞結果と大きな変動ハンドを確認できます。"}
-            </p>
+        <div className="mt-3 space-y-3">
+          <div className="grid gap-3 sm:grid-cols-3">
+            <div className="rounded-xl bg-white/5 px-3 py-2">
+              <p className="text-[11px] font-semibold uppercase tracking-[0.18em] text-emerald-200">
+                確認できた事実
+              </p>
+              <ReviewItemList
+                items={view.facts}
+                emptyText="記録から確認できる事実はまだありません。"
+              />
+            </div>
+            <div className="rounded-xl bg-white/5 px-3 py-2">
+              <p className="text-[11px] font-semibold uppercase tracking-[0.18em] text-amber-200">
+                解釈
+              </p>
+              <ReviewItemList
+                items={view.interpretations}
+                emptyText="結果だけから判断の良否は解釈しません。"
+              />
+            </div>
+            <div className="rounded-xl bg-white/5 px-3 py-2">
+              <p className="text-[11px] font-semibold uppercase tracking-[0.18em] text-sky-200">
+                次の一手
+              </p>
+              <ReviewItemList
+                items={view.nextActions}
+                emptyText="次回はHero actionが残る状態でプレイしてください。"
+              />
+            </div>
           </div>
-          <div className="rounded-xl bg-white/5 px-3 py-2">
-            <p className="text-[11px] font-semibold uppercase tracking-[0.18em] text-amber-200">
-              改善点
+          {view.causalDisclaimer ? (
+            <p className="rounded-xl border border-slate-500/20 bg-slate-950/40 px-3 py-2 text-[10px] text-slate-400">
+              {view.causalDisclaimer}
             </p>
-            <ul className="mt-1 space-y-1 text-xs text-slate-200">
-              {(view.improvementItems.length
-                ? view.improvementItems
-                : ["大きくチップが動いたハンドをリプレイで確認しましょう。"]
-              ).map((item) => (
-                <li key={item}>{item}</li>
-              ))}
-            </ul>
-          </div>
+          ) : null}
           <div className="rounded-xl bg-white/5 px-3 py-2">
             <p className="text-[11px] font-semibold uppercase tracking-[0.18em] text-sky-200">
               Key Hands
@@ -176,6 +247,16 @@ function TournamentReviewSection({ tournamentReview, onOpenReviewReplay }) {
                     </div>
                     {hand.description ? (
                       <p className="text-[11px] text-slate-300">{hand.description}</p>
+                    ) : null}
+                    {Array.isArray(hand.reasonTags) && hand.reasonTags.length ? (
+                      <p className="text-[10px] text-sky-200">
+                        Tags: {hand.reasonTags.join(" / ")}
+                      </p>
+                    ) : null}
+                    {Array.isArray(hand.evidence) && hand.evidence.length ? (
+                      <p className="text-[10px] text-slate-400">
+                        根拠: {hand.evidence.map(formatEvidence).join(" / ")}
+                      </p>
                     ) : null}
                     {typeof onOpenReviewReplay === "function" && hand.replayRef?.target ? (
                       <button
@@ -251,7 +332,7 @@ export default function TournamentResultOverlay({
   return (
     <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/70 px-4">
       <div
-        className="w-full max-w-2xl bg-slate-900 text-white rounded-3xl p-8 space-y-6 shadow-2xl border border-emerald-500/20"
+        className="max-h-[calc(100dvh-2rem)] w-full max-w-2xl space-y-4 overflow-y-auto rounded-3xl border border-emerald-500/20 bg-slate-900 p-4 text-white shadow-2xl sm:space-y-6 sm:p-8"
         data-testid="mtt-result-overlay"
       >
         <header className="text-center space-y-2">

--- a/src/ui/components/__tests__/TournamentResultOverlay.test.jsx
+++ b/src/ui/components/__tests__/TournamentResultOverlay.test.jsx
@@ -36,6 +36,35 @@ function makeTournamentReview(state = "summary", overrides = {}) {
       source: "local-summary",
       items: ["大きくチップが動いたハンドをリプレイで確認しましょう。"],
     },
+    reviewSummary: {
+      source: "local-summary",
+      facts: [{ kind: "fact", text: "12ハンドを記録しました。", evidence: [] }],
+      goodPoints: [
+        {
+          kind: "interpretation",
+          text: "Hand h-7は獲得局面を確認する候補です。",
+          evidence: [{ handId: "h-7", actionSeqRange: { start: 2, end: 2 } }],
+          caveat: "獲得結果だけでは判断の良否を断定できません。",
+        },
+      ],
+      improvementPoints: [],
+      interpretations: [
+        {
+          kind: "interpretation",
+          text: "Hand h-7は獲得局面を確認する候補です。",
+          evidence: [{ handId: "h-7", actionSeqRange: { start: 2, end: 2 } }],
+          caveat: "獲得結果だけでは判断の良否を断定できません。",
+        },
+      ],
+      nextActions: [
+        {
+          kind: "next-action",
+          text: "Hand h-7をリプレイしてください。",
+          evidence: [{ handId: "h-7", actionSeqRange: { start: 2, end: 2 } }],
+        },
+      ],
+      causalDisclaimer: "結果だけから因果関係を断定しません。",
+    },
     keyHands: [
       {
         keyHandId: "biggest-win:h-7",
@@ -222,7 +251,7 @@ describe("TournamentResultOverlay", () => {
     expect(screen.queryByTestId("mtt-tournament-review-replay")).toBeNull();
   });
 
-  it("shows the complete tournament review state without numeric EV claims", () => {
+  it("ignores unstructured AI prose and keeps the grounded local review", () => {
     render(
       <TournamentResultOverlay
         visible
@@ -240,7 +269,9 @@ describe("TournamentResultOverlay", () => {
 
     const review = screen.getByTestId("mtt-tournament-review");
     expect(screen.getByTestId("mtt-tournament-review-status").textContent).toContain("レビュー完了");
-    expect(review.textContent).toContain("終盤のリスク管理");
+    expect(review.textContent).not.toContain("終盤のリスク管理");
+    expect(review.textContent).toContain("Hand h-7");
+    expect(review.textContent).toContain("根拠: Hand h-7 · action 2");
     expect(review.textContent).not.toMatch(/EV\s*[+-]?\d/i);
   });
 
@@ -291,8 +322,9 @@ describe("TournamentResultOverlay", () => {
     );
 
     const review = screen.getByTestId("mtt-tournament-review");
-    expect(screen.getByTestId("mtt-tournament-review-status").textContent).toContain("レビュー未作成");
-    expect(review.textContent).toContain("レビューを作成できませんでした");
+    expect(screen.getByTestId("mtt-tournament-review-status").textContent).toContain("ローカルレビュー");
+    expect(review.textContent).toContain("以下のローカルレビューは引き続き利用できます");
+    expect(review.textContent).toContain("Hand h-7");
     expect(screen.getByTestId("mtt-result-champion").textContent).toContain("Hero");
     expect(screen.getAllByTestId("mtt-result-payout").map((node) => node.textContent)).toEqual([
       "Payout 500",

--- a/src/ui/feedback/__tests__/tournamentReviewContract.test.js
+++ b/src/ui/feedback/__tests__/tournamentReviewContract.test.js
@@ -369,30 +369,146 @@ describe("tournamentReviewContract", () => {
       "bust-hand",
       "biggest-loss",
       "biggest-win",
-      "hero-all-in",
-      "showdown",
-      "large-pot",
       "draw-decision",
-      "final-hand",
     ]);
-    expect(contract.keyHands.find((hand) => hand.reason === "hero-all-in")).toMatchObject({
+    expect(
+      contract.keyHands.find((hand) => hand.reasonTags.includes("hero-all-in")),
+    ).toMatchObject({
       handId: "t-hand-1",
-      title: "Hero all-in",
+      title: "Biggest loss",
       phase: "BET",
-      heroAction: "raise",
       pot: 900,
       heroNet: -500,
-      replayRef: expect.objectContaining({
-        target: expect.objectContaining({
-          handId: "t-hand-1",
-          actionSeqStart: 3,
-        }),
-      }),
+      reasonTags: expect.arrayContaining(["biggest-loss", "hero-all-in", "large-pot"]),
+      evidence: expect.arrayContaining([
+        expect.objectContaining({ reason: "hero-all-in", handId: "t-hand-1" }),
+      ]),
     });
-    expect(contract.keyHands.find((hand) => hand.reason === "draw-decision")).toMatchObject({
-      title: "Draw decision",
-      phase: "DRAW",
-      heroAction: "draw",
+    expect(contract.keyHands.find((hand) => hand.reasonTags.includes("showdown"))).toMatchObject({
+      handId: "t-hand-2",
+      reasonTags: expect.arrayContaining(["biggest-win", "showdown"]),
+    });
+  });
+
+  it("only emits biggest win/loss when a matching signed result exists", () => {
+    const lossesOnly = buildTournamentReviewContract({
+      hands: [makeHand(1, { heroNet: -20 }), makeHand(2, { heroNet: 0 })],
+      hasAuth: false,
+    });
+    const winsOnly = buildTournamentReviewContract({
+      hands: [makeHand(1, { heroNet: 20 }), makeHand(2, { heroNet: 0 })],
+      hasAuth: false,
+    });
+
+    expect(lossesOnly.biggestWin).toBeNull();
+    expect(lossesOnly.keyHands.some((hand) => hand.reasonTags.includes("biggest-win"))).toBe(false);
+    expect(winsOnly.biggestLoss).toBeNull();
+    expect(winsOnly.keyHands.some((hand) => hand.reasonTags.includes("biggest-loss"))).toBe(false);
+  });
+
+  it("deduplicates repeated hand records and aggregates reason tags and action evidence", () => {
+    const repeated = makeHand(4, { heroNet: 300, pot: 900, showdown: true });
+    const contract = buildTournamentReviewContract({
+      hands: [repeated, { ...repeated, bustHand: true }],
+      hasAuth: true,
+    });
+
+    expect(contract.totalHands).toBe(1);
+    expect(contract.keyHands).toHaveLength(1);
+    expect(contract.replayRefs).toHaveLength(1);
+    expect(contract.keyHands[0]).toMatchObject({
+      handId: "t-hand-4",
+      reasonTags: expect.arrayContaining([
+        "bust-hand",
+        "biggest-win",
+        "showdown",
+        "large-pot",
+        "draw-decision",
+        "final-hand",
+      ]),
+    });
+    expect(contract.keyHands[0].evidence.length).toBeGreaterThan(1);
+  });
+
+  it("keeps a grounded local fallback for unauthenticated and API-error states", () => {
+    const base = { hands: [makeHand(0), makeHand(1)], hasAuth: false };
+    const unauthenticated = buildTournamentReviewContract(base);
+    const apiError = buildTournamentReviewContract({
+      ...base,
+      hasAuth: true,
+      requestState: { error: "offline" },
+    });
+
+    for (const contract of [unauthenticated, apiError]) {
+      expect(contract.reviewSummary.source).toBe("local-summary");
+      expect(contract.reviewSummary.facts.length).toBeGreaterThan(0);
+      expect(contract.reviewSummary.nextActions.length).toBeGreaterThan(0);
+      expect(contract.reviewSummary.nextActions[0].evidence[0]).toMatchObject({
+        handId: expect.any(String),
+        actionSeqRange: expect.objectContaining({ start: expect.any(Number) }),
+      });
+    }
+  });
+
+  it("separates facts, interpretations, and next actions without result-only causal claims", () => {
+    const contract = buildTournamentReviewContract({
+      tournament: { buyIn: 100 },
+      placements: [{ id: "hero", place: 1, payout: 500 }],
+      heroPlayerId: "hero",
+      hands: [makeHand(0, { heroNet: 80 }), makeHand(1, { heroNet: -40 })],
+      hasAuth: true,
+    });
+    const summaryText = JSON.stringify(contract.reviewSummary);
+
+    expect(contract.reviewSummary.facts.every((item) => item.kind === "fact")).toBe(true);
+    expect(contract.reviewSummary.interpretations.every((item) => item.kind === "interpretation")).toBe(true);
+    expect(contract.reviewSummary.interpretations.every((item) => item.caveat)).toBe(true);
+    expect(contract.reviewSummary.nextActions.every((item) => item.kind === "next-action")).toBe(true);
+    expect(summaryText).not.toContain("結果につながった");
+    expect(summaryText).not.toContain("良い結果");
+    expect(summaryText).not.toContain("取りすぎた");
+    expect(summaryText).toContain("因果関係は断定しません");
+  });
+
+  it("accepts only structured AI review V2 with valid hand/action evidence", () => {
+    const hands = [makeHand(0, { heroNet: 80 })];
+    const unsafe = buildTournamentReviewContract({
+      hands,
+      hasAuth: true,
+      requestState: { response: { adviceJa: "収支が良いので判断も良かった。" } },
+    });
+    const item = {
+      text: "Hand t-hand-0のaction 1を比較できます。",
+      evidence: [{ handId: "t-hand-0", actionSeqStart: 1, actionSeqEnd: 1 }],
+    };
+    const safe = buildTournamentReviewContract({
+      hands,
+      hasAuth: true,
+      requestState: {
+        response: {
+          reviewV2: {
+            schemaVersion: 2,
+            facts: [item],
+            goodPoints: [{ ...item, caveat: "結果だけでは断定できません。" }],
+            improvementPoints: [{ ...item, caveat: "結果だけでは断定できません。" }],
+            nextActions: [item],
+          },
+        },
+      },
+    });
+
+    expect(unsafe.aiFeedback).toMatchObject({
+      enabled: false,
+      accepted: false,
+      rejectionReason: "structured-review-v2-missing",
+      response: null,
+    });
+    expect(unsafe.reviewSummary.source).toBe("local-summary");
+    expect(safe.aiFeedback).toMatchObject({ enabled: true, accepted: true });
+    expect(safe.reviewSummary.source).toBe("structured-ai");
+    expect(safe.reviewSummary.goodPoints[0].evidence[0]).toMatchObject({
+      handId: "t-hand-0",
+      actionSeqRange: { start: 1, end: 1 },
     });
   });
 });

--- a/src/ui/feedback/tournamentReviewContract.js
+++ b/src/ui/feedback/tournamentReviewContract.js
@@ -1,5 +1,5 @@
 export const TOURNAMENT_REVIEW_CONTRACT_TYPE = "mgx.tournament-review";
-export const TOURNAMENT_REVIEW_SCHEMA_VERSION = 1;
+export const TOURNAMENT_REVIEW_SCHEMA_VERSION = 2;
 
 export const TOURNAMENT_REVIEW_FEEDBACK_STATUS = Object.freeze({
   SUMMARY: "summary",
@@ -146,6 +146,52 @@ function getHandHeroNet(hand = {}) {
 
 function getHandPot(hand = {}) {
   return toNumber(hand.totalPot ?? hand.pot ?? hand.result?.totalPot, 0);
+}
+
+function dedupeHandsById(hands = [], heroSeat = 0) {
+  const byId = new Map();
+  const anonymous = [];
+  (Array.isArray(hands) ? hands : []).forEach((hand) => {
+    const handId = getHandId(hand);
+    if (!handId) {
+      anonymous.push(hand);
+      return;
+    }
+    const current = byId.get(handId);
+    if (!current) {
+      byId.set(handId, hand);
+      return;
+    }
+    const currentActions = collectHeroActions(current, heroSeat).length;
+    const candidateActions = collectHeroActions(hand, heroSeat).length;
+    const primary = candidateActions > currentActions ? hand : current;
+    const secondary = primary === hand ? current : hand;
+    byId.set(handId, {
+      ...secondary,
+      ...primary,
+      handId,
+      heroBusted: Boolean(
+        current.heroBusted ||
+        hand.heroBusted ||
+        [current, hand].some((record) =>
+          (Array.isArray(record?.seats) ? record.seats : []).some(
+            (seat) =>
+              isHeroSeat(seat, heroSeat) &&
+              (seat.busted === true || seat.stack === 0),
+          ),
+        )
+      ),
+      bustHand: Boolean(current.bustHand || hand.bustHand),
+      showdown: hasShowdownEvidence(current) || hasShowdownEvidence(hand),
+      heroNet:
+        getHandHeroNet(primary) !== 0
+          ? getHandHeroNet(primary)
+          : getHandHeroNet(secondary),
+      pot: Math.max(getHandPot(current), getHandPot(hand)),
+      totalPot: Math.max(getHandPot(current), getHandPot(hand)),
+    });
+  });
+  return [...byId.values(), ...anonymous];
 }
 
 function normalizePlacement(entry = {}) {
@@ -314,7 +360,7 @@ function buildKeyHand({ hand, reason, label, title, description, heroSeat = 0 })
     selectedAction?.phase ?? selectedAction?.street ?? hand.phase ?? hand.street,
   );
   return {
-    keyHandId: `${reason}:${normalized.handId}`,
+    keyHandId: normalized.handId,
     handId: normalized.handId,
     variantId: normalized.variantId,
     reason,
@@ -328,25 +374,65 @@ function buildKeyHand({ hand, reason, label, title, description, heroSeat = 0 })
     heroNet: normalized.heroNet,
     resultDelta: normalized.heroNet,
     actionSeqRange: selectedRange,
+    reasonTags: [reason],
+    evidence: [
+      {
+        reason,
+        handId: normalized.handId,
+        actionSeqRange: selectedRange,
+        phase,
+        heroAction: selectedAction ? normalizeActionType(selectedAction) : null,
+      },
+    ],
     replayRef,
   };
 }
 
-function uniqueKeyHands(entries = []) {
-  const seen = new Set();
-  return entries.filter((entry) => {
-    if (!entry?.handId) return false;
-    const key = `${entry.reason}:${entry.handId}`;
-    if (seen.has(key)) return false;
-    seen.add(key);
-    return true;
+function mergeKeyHands(entries = []) {
+  const merged = new Map();
+  entries.filter(Boolean).forEach((entry) => {
+    if (!entry?.handId) return;
+    const current = merged.get(entry.handId);
+    if (!current) {
+      merged.set(entry.handId, {
+        ...entry,
+        keyHandId: entry.handId,
+        reasonTags: [...new Set(entry.reasonTags ?? [entry.reason])],
+        evidence: [...(entry.evidence ?? [])],
+      });
+      return;
+    }
+    const reasonTags = [
+      ...(current.reasonTags ?? [current.reason]),
+      ...(entry.reasonTags ?? [entry.reason]),
+    ].filter(Boolean);
+    const evidence = [...(current.evidence ?? []), ...(entry.evidence ?? [])].filter(
+      (item, index, list) =>
+        list.findIndex(
+          (candidate) =>
+            candidate.reason === item.reason &&
+            candidate.handId === item.handId &&
+            candidate.actionSeqRange?.start === item.actionSeqRange?.start &&
+            candidate.actionSeqRange?.end === item.actionSeqRange?.end,
+        ) === index,
+    );
+    merged.set(entry.handId, {
+      ...current,
+      reasonTags: [...new Set(reasonTags)],
+      evidence,
+    });
   });
+  return [...merged.values()];
 }
 
 function buildTournamentKeyHands(hands = [], heroSeat = 0) {
   const safeHands = Array.isArray(hands) ? hands : [];
-  const biggestWinHand = [...safeHands].sort((a, b) => getHandHeroNet(b) - getHandHeroNet(a))[0] ?? null;
-  const biggestLossHand = [...safeHands].sort((a, b) => getHandHeroNet(a) - getHandHeroNet(b))[0] ?? null;
+  const biggestWinHand = [...safeHands]
+    .filter((hand) => getHandHeroNet(hand) > 0)
+    .sort((a, b) => getHandHeroNet(b) - getHandHeroNet(a))[0] ?? null;
+  const biggestLossHand = [...safeHands]
+    .filter((hand) => getHandHeroNet(hand) < 0)
+    .sort((a, b) => getHandHeroNet(a) - getHandHeroNet(b))[0] ?? null;
   const bustHand =
     [...safeHands].reverse().find((hand) => {
       if (hand?.bustHand === true || hand?.heroBusted === true) return true;
@@ -380,7 +466,7 @@ function buildTournamentKeyHands(hands = [], heroSeat = 0) {
     label: "Bust hand",
     heroSeat,
   });
-  const keyHands = uniqueKeyHands([
+  const keyHands = mergeKeyHands([
     bust,
     biggestLoss,
     biggestWin,
@@ -396,7 +482,7 @@ function buildTournamentKeyHands(hands = [], heroSeat = 0) {
     biggestWin,
     biggestLoss,
     keyHands,
-    replayRefs: uniqueKeyHands(keyHands).map((entry) => entry.replayRef).filter(Boolean),
+    replayRefs: keyHands.map((entry) => entry.replayRef).filter(Boolean),
   };
 }
 
@@ -480,37 +566,246 @@ function normalizeFeedbackStatus({
   };
 }
 
-function buildNextImprovements({ handCount = 0, heroActionCount = 0, result = {} } = {}) {
-  if (handCount === 0 || heroActionCount === 0) {
-    return ["次回はハンド履歴が残る状態でプレイすると、重要局面を振り返れます。"];
-  }
-  const items = ["大きくチップが動いたハンドをリプレイで確認しましょう。"];
-  if (Number.isFinite(result.roi) && result.roi < 0) {
-    items.push("入賞前後のリスクを取りすぎた局面がないか確認しましょう。");
-  } else {
-    items.push("良い結果につながった参加レンジとドロー判断を次回も再現しましょう。");
-  }
-  return items;
+function evidenceForKeyHand(keyHand) {
+  if (!keyHand?.handId) return [];
+  const evidence = Array.isArray(keyHand.evidence) ? keyHand.evidence : [];
+  if (evidence.length) return evidence;
+  return [
+    {
+      reason: keyHand.reason ?? "key-hand",
+      handId: keyHand.handId,
+      actionSeqRange: keyHand.actionSeqRange ?? null,
+      phase: keyHand.phase ?? null,
+      heroAction: keyHand.heroAction ?? null,
+    },
+  ];
 }
 
-function buildReviewSummary({ feedbackStatus = {}, handCount = 0, heroActionCount = 0, result = {}, keyHands = [] } = {}) {
-  const goodPoints = [];
-  if (Number.isFinite(result.roi) && result.roi > 0) {
-    goodPoints.push("入賞結果につながった判断を振り返れます。");
-  } else if (result.placement != null) {
-    goodPoints.push("最終順位とチップ変動の大きい局面を確認できます。");
-  } else {
-    goodPoints.push("大会終了時点の結果を整理できます。");
+function reviewItem({ text, kind, keyHand = null, caveat = null }) {
+  return {
+    kind,
+    text,
+    evidence: evidenceForKeyHand(keyHand),
+    caveat,
+  };
+}
+
+function findKeyHand(keyHands = [], reason) {
+  return keyHands.find((hand) =>
+    (hand.reasonTags ?? [hand.reason]).includes(reason),
+  ) ?? null;
+}
+
+function buildLocalReviewSummary({
+  feedbackStatus = {},
+  handCount = 0,
+  heroActionCount = 0,
+  result = {},
+  keyHands = [],
+} = {}) {
+  const biggestWin = findKeyHand(keyHands, "biggest-win");
+  const biggestLoss = findKeyHand(keyHands, "biggest-loss");
+  const drawDecision = findKeyHand(keyHands, "draw-decision");
+  const firstEvidenceHand = keyHands[0] ?? null;
+  const facts = [
+    reviewItem({
+      kind: "fact",
+      text: `記録されたハンドは${handCount}件、Heroのアクションは${heroActionCount}件です。`,
+    }),
+  ];
+  if (result.placement != null || Number.isFinite(result.payout)) {
+    facts.push(
+      reviewItem({
+        kind: "fact",
+        text: `大会結果は${result.placement ?? "--"}位、獲得賞金は${toNumber(result.payout, 0)}です。`,
+      }),
+    );
   }
-  const improvementPoints = buildNextImprovements({ handCount, heroActionCount, result });
+  if (biggestWin) {
+    facts.push(
+      reviewItem({
+        kind: "fact",
+        text: `Hand ${biggestWin.handId}で記録上最大のチップ増加（${biggestWin.heroNet >= 0 ? "+" : ""}${biggestWin.heroNet}）がありました。`,
+        keyHand: biggestWin,
+      }),
+    );
+  }
+  if (biggestLoss) {
+    facts.push(
+      reviewItem({
+        kind: "fact",
+        text: `Hand ${biggestLoss.handId}で記録上最大のチップ減少（${biggestLoss.heroNet}）がありました。`,
+        keyHand: biggestLoss,
+      }),
+    );
+  }
+
+  const goodPoints = [];
+  if (biggestWin) {
+    goodPoints.push(
+      reviewItem({
+        kind: "interpretation",
+        text: `Hand ${biggestWin.handId}は獲得局面の判断過程を確認する候補です。`,
+        keyHand: biggestWin,
+        caveat: "チップ増加だけでは、その判断が最善だったとは断定できません。",
+      }),
+    );
+  } else if (firstEvidenceHand) {
+    goodPoints.push(
+      reviewItem({
+        kind: "interpretation",
+        text: `Hand ${firstEvidenceHand.handId}には具体的なアクション記録があり、判断過程を振り返れます。`,
+        keyHand: firstEvidenceHand,
+        caveat: "大会順位や収支だけから判断の質は評価しません。",
+      }),
+    );
+  }
+
+  const improvementPoints = [];
+  if (biggestLoss) {
+    improvementPoints.push(
+      reviewItem({
+        kind: "interpretation",
+        text: `Hand ${biggestLoss.handId}は損失局面の選択肢を比較する候補です。`,
+        keyHand: biggestLoss,
+        caveat: "損失した事実だけでは、ミスだったとは断定できません。",
+      }),
+    );
+  }
+  if (drawDecision && drawDecision.handId !== biggestLoss?.handId) {
+    improvementPoints.push(
+      reviewItem({
+        kind: "interpretation",
+        text: `Hand ${drawDecision.handId}のドロー枚数と、その時点の選択肢を再確認できます。`,
+        keyHand: drawDecision,
+        caveat: "最終結果だけではドロー判断の良否は決まりません。",
+      }),
+    );
+  }
+
+  const actionTarget = biggestLoss ?? drawDecision ?? biggestWin ?? firstEvidenceHand;
+  const nextActions = actionTarget
+    ? [
+        reviewItem({
+          kind: "next-action",
+          text: `Hand ${actionTarget.handId}をリプレイし、表示されたHero actionと当時のlegal actionsを比較してください。`,
+          keyHand: actionTarget,
+        }),
+      ]
+    : [
+        reviewItem({
+          kind: "next-action",
+          text: "次回はハンド履歴とHero actionが残る状態でプレイしてください。",
+        }),
+      ];
+
   return {
     state: feedbackStatus.state ?? TOURNAMENT_REVIEW_FEEDBACK_STATUS.SUMMARY,
-    source: feedbackStatus.source ?? "local-summary",
+    source: "local-summary",
     reviewedHands: handCount,
     heroActionCount,
     keyHandCount: keyHands.length,
+    facts,
     goodPoints,
     improvementPoints,
+    interpretations: [...goodPoints, ...improvementPoints],
+    nextActions,
+    causalDisclaimer:
+      "順位・ROI・単一ハンドの結果だけから、意思決定の良否や結果との因果関係は断定しません。",
+  };
+}
+
+function normalizeAiEvidence(evidence, knownHands, heroActions) {
+  if (!Array.isArray(evidence) || evidence.length === 0) return null;
+  const normalized = evidence.map((entry) => {
+    const handId = nullableString(entry?.handId);
+    if (!handId || !knownHands.has(handId)) return null;
+    const start = Number(entry?.actionSeqStart ?? entry?.actionSeqRange?.start);
+    const end = Number(entry?.actionSeqEnd ?? entry?.actionSeqRange?.end ?? start);
+    if (!Number.isInteger(start) || !Number.isInteger(end) || start <= 0 || end < start) {
+      return null;
+    }
+    const actionExists = heroActions.some(
+      (action) =>
+        action.handId === handId &&
+        Number.isInteger(action.actionSeq) &&
+        action.actionSeq >= start &&
+        action.actionSeq <= end,
+    );
+    if (!actionExists) return null;
+    return { handId, actionSeqRange: { start, end } };
+  });
+  return normalized.every(Boolean) ? normalized : null;
+}
+
+function normalizeAiItems(items, kind, knownHands, heroActions) {
+  if (!Array.isArray(items)) return null;
+  const normalized = items.slice(0, 4).map((item) => {
+    if (!item || typeof item !== "object") return null;
+    const text = nullableString(item.text);
+    const evidence = normalizeAiEvidence(item.evidence, knownHands, heroActions);
+    if (!text || text.length > 240 || !evidence) return null;
+    return {
+      kind,
+      text,
+      evidence,
+      caveat:
+        kind === "interpretation"
+          ? nullableString(item.caveat) ??
+            "結果だけから意思決定の良否や因果関係は断定できません。"
+          : null,
+    };
+  });
+  return normalized.every(Boolean) ? normalized : null;
+}
+
+function normalizeStructuredAiReview(response, keyHands, heroActions) {
+  const payload = response?.reviewV2 ?? response?.structuredReview ?? null;
+  if (!payload || typeof payload !== "object" || Number(payload.schemaVersion) !== 2) {
+    return { accepted: false, reason: "structured-review-v2-missing", summary: null };
+  }
+  const knownHands = new Set(keyHands.map((hand) => hand.handId));
+  const facts = normalizeAiItems(payload.facts, "fact", knownHands, heroActions);
+  const goodPoints = normalizeAiItems(
+    payload.goodPoints,
+    "interpretation",
+    knownHands,
+    heroActions,
+  );
+  const improvementPoints = normalizeAiItems(
+    payload.improvementPoints,
+    "interpretation",
+    knownHands,
+    heroActions,
+  );
+  const nextActions = normalizeAiItems(
+    payload.nextActions,
+    "next-action",
+    knownHands,
+    heroActions,
+  );
+  if (
+    !facts ||
+    !facts.length ||
+    !goodPoints ||
+    !improvementPoints ||
+    !nextActions ||
+    !nextActions.length
+  ) {
+    return { accepted: false, reason: "invalid-or-ungrounded-ai-review", summary: null };
+  }
+  return {
+    accepted: true,
+    reason: null,
+    summary: {
+      facts,
+      goodPoints,
+      improvementPoints,
+      interpretations: [...goodPoints, ...improvementPoints],
+      nextActions,
+      causalDisclaimer:
+        "AIの解釈は参考情報です。順位・ROI・結果だけから因果関係を断定しません。",
+    },
   };
 }
 
@@ -548,7 +843,7 @@ export function buildTournamentReviewContract({
   savedFeedback = null,
   hasAuth = false,
 } = {}) {
-  const safeHands = Array.isArray(hands) ? hands : [];
+  const safeHands = dedupeHandsById(hands, heroSeat);
   const tournamentId = getTournamentId(tournament);
   const normalizedHands = safeHands.map((hand) => normalizeHand(hand, heroSeat));
   const variantIds = [...new Set(normalizedHands.map((hand) => hand.variantId).filter(Boolean))];
@@ -573,6 +868,26 @@ export function buildTournamentReviewContract({
     handCount,
     heroActionCount,
   });
+  const localReviewSummary = buildLocalReviewSummary({
+    feedbackStatus,
+    handCount,
+    heroActionCount,
+    result,
+    keyHands,
+  });
+  const rawAiResponse = requestState.response ?? savedFeedback?.response ?? null;
+  const structuredAiReview = normalizeStructuredAiReview(
+    rawAiResponse,
+    keyHands,
+    heroActions,
+  );
+  const reviewSummary = structuredAiReview.accepted
+    ? {
+        ...localReviewSummary,
+        ...structuredAiReview.summary,
+        source: "structured-ai",
+      }
+    : localReviewSummary;
   const limitations = [];
   if (!handCount) limitations.push("hand-history-missing");
   if (!heroActionCount) limitations.push("hero-actions-missing");
@@ -601,15 +916,9 @@ export function buildTournamentReviewContract({
     keyHands,
     result,
     replayRefs,
-    reviewSummary: buildReviewSummary({
-      feedbackStatus,
-      handCount,
-      heroActionCount,
-      result,
-      keyHands,
-    }),
+    reviewSummary,
     reviewDepth:
-      feedbackStatus.state === TOURNAMENT_REVIEW_FEEDBACK_STATUS.COMPLETE
+      structuredAiReview.accepted
         ? "ai-assisted"
         : handCount && heroActionCount
           ? "hand-history"
@@ -624,8 +933,8 @@ export function buildTournamentReviewContract({
       limitations,
     },
     nextImprovements: {
-      source: feedbackStatus.state === TOURNAMENT_REVIEW_FEEDBACK_STATUS.COMPLETE ? "ai" : "local-summary",
-      items: buildNextImprovements({ handCount, heroActionCount, result }),
+      source: reviewSummary.source,
+      items: reviewSummary.nextActions.map((item) => item.text),
     },
     feedbackStatus: {
       ...feedbackStatus,
@@ -634,11 +943,13 @@ export function buildTournamentReviewContract({
       heroActionCount,
     },
     aiFeedback: {
-      enabled: false,
+      enabled: structuredAiReview.accepted,
       optional: true,
       state: feedbackStatus.state,
-      source: feedbackStatus.source,
-      response: requestState.response ?? savedFeedback?.response ?? null,
+      source: structuredAiReview.accepted ? "structured-ai" : "local-summary",
+      accepted: structuredAiReview.accepted,
+      rejectionReason: structuredAiReview.reason,
+      response: structuredAiReview.accepted ? rawAiResponse : null,
       error: feedbackStatus.error,
     },
   };

--- a/tests/e2e/tournament-review-overlay.spec.ts
+++ b/tests/e2e/tournament-review-overlay.spec.ts
@@ -134,8 +134,8 @@ test.describe("Tournament Review result overlay", () => {
       }),
     );
 
-    await expect(page.getByTestId("mtt-tournament-review-status")).toContainText("レビュー未作成");
-    await expect(page.getByTestId("mtt-tournament-review")).toContainText("レビューを作成できませんでした");
+    await expect(page.getByTestId("mtt-tournament-review-status")).toContainText("ローカルレビュー");
+    await expect(page.getByTestId("mtt-tournament-review")).toContainText("ローカルレビューは引き続き利用できます");
     await expect(page.getByTestId("mtt-result-champion")).toContainText("Champion");
     await expect(page.getByTestId("mtt-result-payout").first()).toContainText(/Payout \d+/);
   });


### PR DESCRIPTION
## Summary
- ground feedback in deduplicated hand/action evidence
- separate facts, interpretation and next action without result-based causal claims
- preserve local feedback for unauthenticated/API-failure cases
- accept AI feedback only when schema-v2 evidence references validate
- improve mobile review scrolling and positive/negative hand semantics

## Validation
- semantic/UI: 23 passed
- Tier1: 1,970 passed / 11 skipped
- Tier2: 156 passed
- related E2E: 6 passed
- lint and build passed