### PR TITLE
test(games): enforce deterministic multi-hand quality gates

### DIFF
--- a/src/games/badugi/utils/__tests__/deckDeterminism.test.js
+++ b/src/games/badugi/utils/__tests__/deckDeterminism.test.js
@@ -1,0 +1,19 @@
+import { describe, expect, it } from "vitest";
+import { createDeterministicRng } from "../../../testing/deterministicRng.js";
+import { DeckManager } from "../deck.js";
+
+function drawSequence(seed, count = 12) {
+  const deck = new DeckManager({ rng: createDeterministicRng(seed) });
+  deck.reset();
+  return deck.draw(count);
+}
+
+describe("DeckManager deterministic shuffle path", () => {
+  it("replays the same shuffled cards for the same seed", () => {
+    expect(drawSequence("repeatable-session")).toEqual(drawSequence("repeatable-session"));
+  });
+
+  it("changes the shuffled cards when the seed changes", () => {
+    expect(drawSequence("session-a")).not.toEqual(drawSequence("session-b"));
+  });
+});

--- a/src/games/badugi/utils/deck.js
+++ b/src/games/badugi/utils/deck.js
@@ -26,6 +26,7 @@ export class DeckManager {
     const normalized =
       typeof options === "boolean" ? { debug: options } : options ?? {};
     this.debug = Boolean(normalized.debug);
+    this.rng = typeof normalized.rng === "function" ? normalized.rng : Math.random;
     this.seedDeck = Array.isArray(normalized.seedDeck)
       ? [...normalized.seedDeck]
       : null;
@@ -50,7 +51,7 @@ export class DeckManager {
 
   #shuffle(array) {
     for (let i = array.length - 1; i > 0; i--) {
-      const j = Math.floor(Math.random() * (i + 1));
+      const j = Math.floor(this.rng() * (i + 1));
       [array[i], array[j]] = [array[j], array[i]];
     }
     return array;

--- a/src/games/config/__tests__/variantManifestValidator.test.js
+++ b/src/games/config/__tests__/variantManifestValidator.test.js
@@ -1,0 +1,42 @@
+import { describe, expect, it } from "vitest";
+import {
+  KNOWN_VARIANT_MANIFEST_EXCEPTIONS,
+  auditVariantManifest,
+  buildCanonicalVariantManifest,
+} from "../variantManifestValidator.js";
+
+describe("canonical variant manifest validator", () => {
+  it("joins all runtime registries around the 36-entry catalog", () => {
+    const manifest = buildCanonicalVariantManifest();
+    expect(manifest).toHaveLength(36);
+    expect(new Set(manifest.map((entry) => entry.id))).toHaveProperty("size", 36);
+  });
+
+  it("rejects every unclassified registry or definition inconsistency", () => {
+    const audit = auditVariantManifest();
+    expect(audit.unexpectedIssues, JSON.stringify(audit.unexpectedIssues, null, 2)).toEqual([]);
+    expect(audit.allowlistedIssues.length).toBeGreaterThan(0);
+    audit.allowlistedIssues.forEach((issue) => {
+      expect(issue.reason).toEqual(expect.any(String));
+      expect(issue.reason.length).toBeGreaterThan(20);
+    });
+  });
+
+  it("keeps known debt explicit and rejects stale exception keys", () => {
+    const audit = auditVariantManifest();
+    expect(new Set(audit.allowlistedIssues.map((issue) => issue.key))).toEqual(
+      new Set(Object.keys(KNOWN_VARIANT_MANIFEST_EXCEPTIONS)),
+    );
+  });
+
+  it("keeps canonical Hold'em and Omaha hole-card counts aligned", () => {
+    const manifest = buildCanonicalVariantManifest();
+    expect(manifest.find((entry) => entry.id === "B01")).toMatchObject({
+      holeCards: 2,
+      definitionHoleCards: 2,
+    });
+    expect(manifest.find((entry) => entry.id === "B09")).toMatchObject({
+      holeCards: 4,
+    });
+  });
+});

--- a/src/games/config/multiGameList.json
+++ b/src/games/config/multiGameList.json
@@ -3,7 +3,7 @@
         "id":  "B01",
         "name":  "NL Hold\u0027em",
         "category":  "board",
-        "holeCards":  4,
+        "holeCards":  2,
         "drawRounds":  0,
         "board":  {
                       "type":  "flop-turn-river",
@@ -248,7 +248,7 @@
         "id":  "B09",
         "name":  "FLO8",
         "category":  "board",
-        "holeCards":  2,
+        "holeCards":  4,
         "drawRounds":  0,
         "board":  {
                       "type":  "flop-turn-river",

--- a/src/games/config/variantManifestValidator.js
+++ b/src/games/config/variantManifestValidator.js
@@ -1,0 +1,171 @@
+import GameRegistry from "../_core/GameRegistry.js";
+import { GAME_VARIANTS as CONTROLLER_VARIANTS } from "../core/variants.js";
+import { GAME_VARIANTS as UI_VARIANTS } from "../../ui/game/variants.js";
+import { GAME_VARIANTS as CATALOG_VARIANTS } from "./variantCatalog.js";
+import {
+  VARIANT_AVAILABILITY,
+  getVariantAvailability,
+} from "./variantAvailability.js";
+
+const DRAW_DEFINITION_DEBT = [
+  "D01", "D02", "D04", "D05", "D06", "D07",
+  "S01", "S02", "S03", "S04", "S05", "S06", "S07",
+];
+
+export const KNOWN_VARIANT_MANIFEST_EXCEPTIONS = Object.freeze({
+  ...Object.fromEntries(
+    DRAW_DEFINITION_DEBT.map((variantId) => [
+      `${variantId}:game-definition-missing`,
+      "Draw-family runtime predates GameDefinition; controller and engine are registered separately.",
+    ]),
+  ),
+  "B09:definition-contract-incomplete":
+    "FLO8 currently uses a minimal derived definition and inherits runtime behavior from PLO8.",
+  "ST4:definition-contract-incomplete":
+    "Razzdugi currently uses a minimal definition consumed by the shared Stud controller.",
+  "ST5:definition-contract-incomplete":
+    "Razzducey currently uses a minimal definition consumed by the shared Stud controller.",
+  "CP1:definition-contract-incomplete":
+    "Classic Chinese Poker uses its dedicated set/showdown controller rather than the street GameDefinition contract.",
+  "CP1:controller-registry-missing":
+    "Classic Chinese Poker is routed through its dedicated controller outside the shared controller registry.",
+});
+
+const REQUIRED_DEFINITION_FIELDS = Object.freeze([
+  "id",
+  "label",
+  "variant",
+  "streets",
+  "handStructure",
+  "evaluateHand",
+]);
+
+function uiEntryFor(variant) {
+  const ids = new Set([variant.id, variant.engineKey].filter(Boolean));
+  return UI_VARIANTS.find((entry) => ids.has(entry.id)) ?? null;
+}
+
+function controllerEntryFor(variant) {
+  return CONTROLLER_VARIANTS[variant.engineKey] ?? null;
+}
+
+function definitionFor(variant) {
+  return GameRegistry.get(variant.engineKey) ?? null;
+}
+
+function missingDefinitionFields(definition) {
+  return REQUIRED_DEFINITION_FIELDS.filter((field) => {
+    const value = definition?.[field];
+    if (field === "streets") return !Array.isArray(value) || value.length === 0;
+    if (field === "handStructure") return !value || typeof value !== "object";
+    if (field === "evaluateHand") return typeof value !== "function";
+    return value == null || value === "";
+  });
+}
+
+export function buildCanonicalVariantManifest() {
+  return CATALOG_VARIANTS.map((variant) => {
+    const availability = getVariantAvailability(variant.engineKey ?? variant.id);
+    const controller = controllerEntryFor(variant);
+    const definition = definitionFor(variant);
+    const ui = uiEntryFor(variant);
+    return Object.freeze({
+      id: variant.id,
+      engineKey: variant.engineKey,
+      name: variant.name,
+      category: variant.category,
+      holeCards: variant.holeCards,
+      catalogStatus: variant.status,
+      availability: availability.availability,
+      availabilityKey: availability.key,
+      controllerVariantId: controller?.variantId ?? null,
+      definitionVariant: definition?.variant ?? null,
+      definitionHoleCards: definition?.handStructure?.hole ?? null,
+      uiId: ui?.id ?? null,
+      uiEnabled: ui?.enabled ?? false,
+    });
+  });
+}
+
+export function auditVariantManifest({
+  knownExceptions = KNOWN_VARIANT_MANIFEST_EXCEPTIONS,
+} = {}) {
+  const issues = [];
+  const ids = new Set();
+  const engineKeys = new Set();
+
+  for (const variant of CATALOG_VARIANTS) {
+    if (ids.has(variant.id)) {
+      issues.push({ key: `${variant.id}:duplicate-catalog-id`, variantId: variant.id });
+    }
+    ids.add(variant.id);
+
+    if (!variant.engineKey) {
+      issues.push({ key: `${variant.id}:engine-key-missing`, variantId: variant.id });
+    } else if (engineKeys.has(variant.engineKey)) {
+      issues.push({ key: `${variant.id}:duplicate-engine-key`, variantId: variant.id });
+    }
+    engineKeys.add(variant.engineKey);
+
+    const controller = controllerEntryFor(variant);
+    if (!controller) {
+      issues.push({ key: `${variant.id}:controller-registry-missing`, variantId: variant.id });
+    } else if (controller.variantId !== variant.id) {
+      issues.push({
+        key: `${variant.id}:controller-variant-id-mismatch`,
+        variantId: variant.id,
+        expected: variant.id,
+        actual: controller.variantId,
+      });
+    }
+
+    const ui = uiEntryFor(variant);
+    if (!ui) {
+      issues.push({ key: `${variant.id}:ui-registry-missing`, variantId: variant.id });
+    }
+
+    const availability = getVariantAvailability(variant.engineKey ?? variant.id);
+    if (!availability.key || !VARIANT_AVAILABILITY[availability.key]) {
+      issues.push({ key: `${variant.id}:availability-missing`, variantId: variant.id });
+    }
+
+    const definition = definitionFor(variant);
+    if (!definition) {
+      issues.push({ key: `${variant.id}:game-definition-missing`, variantId: variant.id });
+    } else {
+      const missingFields = missingDefinitionFields(definition);
+      if (missingFields.length) {
+        issues.push({
+          key: `${variant.id}:definition-contract-incomplete`,
+          variantId: variant.id,
+          missingFields,
+        });
+      }
+      if (
+        Number.isFinite(variant.holeCards) &&
+        Number.isFinite(definition.handStructure?.hole) &&
+        variant.holeCards !== definition.handStructure.hole
+      ) {
+        issues.push({
+          key: `${variant.id}:hole-card-count-mismatch`,
+          variantId: variant.id,
+          expected: definition.handStructure.hole,
+          actual: variant.holeCards,
+        });
+      }
+    }
+  }
+
+  const classified = issues.map((issue) => ({
+    ...issue,
+    allowlisted: Object.prototype.hasOwnProperty.call(knownExceptions, issue.key),
+    reason: knownExceptions[issue.key] ?? null,
+  }));
+  return {
+    manifest: buildCanonicalVariantManifest(),
+    issues: classified,
+    unexpectedIssues: classified.filter((issue) => !issue.allowlisted),
+    allowlistedIssues: classified.filter((issue) => issue.allowlisted),
+  };
+}
+

--- a/src/games/nlh/NLHGameController.js
+++ b/src/games/nlh/NLHGameController.js
@@ -43,8 +43,8 @@ function buildPlayerFromSeat(seat, idx) {
   };
 }
 
-function defaultDeckFactory() {
-  return new DeckManager();
+function defaultDeckFactory(options = {}) {
+  return new DeckManager(options);
 }
 
 function defaultTableConfig() {
@@ -142,8 +142,8 @@ export class NLHGameController {
 
   resetDeck() {
     const deckInstance = this.config.deckFactory
-      ? this.config.deckFactory()
-      : defaultDeckFactory();
+      ? this.config.deckFactory({ rng: this.config.rng })
+      : defaultDeckFactory({ rng: this.config.rng });
     this.deck = deckInstance;
     if (typeof this.deck.reset === "function") {
       this.deck.reset();

--- a/src/games/stud/StudGameController.js
+++ b/src/games/stud/StudGameController.js
@@ -104,9 +104,10 @@ export class StudGameController {
     tableConfig = defaultTableConfig(),
     gameDefinition = StudGameDefinition,
     variant = "stud",
-    deckFactory = () => new DeckManager(),
+    rng = Math.random,
+    deckFactory = ({ rng: deckRng } = {}) => new DeckManager({ rng: deckRng }),
   } = {}) {
-    this.config = { tableConfig, gameDefinition, deckFactory };
+    this.config = { tableConfig, gameDefinition, deckFactory, rng };
     this.variant = variant;
     this.handCounter = 0;
     this.raiseCap = 4;
@@ -194,7 +195,7 @@ export class StudGameController {
   }
 
   resetDeck() {
-    this.deck = this.config.deckFactory();
+    this.deck = this.config.deckFactory({ rng: this.config.rng });
     if (typeof this.deck.reset === "function") this.deck.reset();
   }
 

--- a/src/games/testing/deterministicRng.js
+++ b/src/games/testing/deterministicRng.js
@@ -1,0 +1,22 @@
+function hashSeed(seed) {
+  const text = String(seed ?? "mgx-default-seed");
+  let hash = 2166136261;
+  for (let index = 0; index < text.length; index += 1) {
+    hash ^= text.charCodeAt(index);
+    hash = Math.imul(hash, 16777619);
+  }
+  return hash >>> 0;
+}
+
+export function createDeterministicRng(seed) {
+  let state = hashSeed(seed);
+  return function deterministicRandom() {
+    state = (state + 0x6d2b79f5) >>> 0;
+    let value = state;
+    value = Math.imul(value ^ (value >>> 15), value | 1);
+    value ^= value + Math.imul(value ^ (value >>> 7), value | 61);
+    return ((value ^ (value >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+export default createDeterministicRng;

--- a/src/games/testing/ev/evIntegrityChecker.js
+++ b/src/games/testing/ev/evIntegrityChecker.js
@@ -319,7 +319,9 @@ export function validateHandEvIntegrity({
     }
   });
 
-  if (!resolvedResult && options.allowMissingResult !== true) {
+  if (!resolvedResult && options.requireResult === true) {
+    addError(errors, "missing_result", { message: "No terminal result was available for EV validation." });
+  } else if (!resolvedResult && options.allowMissingResult !== true) {
     warnings.push({ code: "missing_result", message: "No terminal result was available for EV validation." });
   }
 
@@ -364,8 +366,16 @@ export function validateHandEvIntegrity({
   }
 
   if (options.strictChipConservation) {
+    const terminalPotIsResultEcho = options.terminalPotIsResultEcho === true;
+    if (
+      terminalPotIsResultEcho &&
+      resolvedResult &&
+      !approxEqual(afterLivePot, potTotal, options.potEpsilon ?? EPSILON)
+    ) {
+      addError(errors, "terminal_pot_echo_mismatch", { afterLivePot, potTotal });
+    }
     const beforeTotal = beforeStackTotal + getLivePot(beforeState);
-    const afterTotal = afterStackTotal + afterLivePot;
+    const afterTotal = afterStackTotal + (terminalPotIsResultEcho ? 0 : afterLivePot);
     if (!approxEqual(beforeTotal, afterTotal, options.chipEpsilon ?? EPSILON)) {
       addError(errors, "chip_conservation_mismatch", { beforeTotal, afterTotal });
     }

--- a/src/games/testing/ev/strictVariantSettlementGate.js
+++ b/src/games/testing/ev/strictVariantSettlementGate.js
@@ -1,0 +1,141 @@
+import { getVariantById } from "../../config/variantCatalog.js";
+import { compareNlhHands, evaluateNlhHand } from "../../nlh/utils/nlhEvaluator.js";
+import { extractPayouts, validateHandEvIntegrity } from "./evIntegrityChecker.js";
+
+const FAMILY_ALLOWLISTS = Object.freeze([
+  {
+    ids: ["B02", "B03", "B04"],
+    reason: "Board pilot expansion awaits variant-specific fixed-limit and three-hole settlement fixtures.",
+  },
+  {
+    ids: ["B05", "B06", "B07", "B08", "B09"],
+    reason: "Omaha settlement awaits strict must-use-two, side-pot, hi/lo, quartering, and odd-chip fixtures.",
+  },
+  {
+    ids: ["D01", "D02", "D03", "D04", "D05", "D06", "D07", "S01", "S02", "S03", "S04", "S05", "S06", "S07"],
+    reason: "Draw settlement awaits normalized terminal pot snapshots and component-pot winner replay.",
+  },
+  {
+    ids: ["H01", "H02", "H03", "H04", "H05", "H06"],
+    reason: "Dramaha settlement awaits board/draw component winner and odd-chip verification.",
+  },
+  {
+    ids: ["ST1", "ST2", "ST3", "ST4", "ST5", "ST6"],
+    reason: "Stud settlement awaits bring-in history replay and split-component winner verification.",
+  },
+  {
+    ids: ["CP1"],
+    reason: "Classic Chinese Poker uses points rather than chip-pot settlement; a dedicated strict points gate is required.",
+  },
+]);
+
+export const STRICT_SETTLEMENT_ALLOWLIST = Object.freeze(
+  Object.fromEntries(
+    FAMILY_ALLOWLISTS.flatMap(({ ids, reason }) => ids.map((id) => [id, reason])),
+  ),
+);
+
+export function getStrictSettlementPolicy(variantId) {
+  const variant = getVariantById(variantId);
+  if (!variant) {
+    return { variantId, status: "UNKNOWN", reason: "Variant is absent from the canonical catalog." };
+  }
+  if (variant.id === "B01") {
+    return { variantId: variant.id, status: "ENFORCED", reason: null };
+  }
+  const reason = STRICT_SETTLEMENT_ALLOWLIST[variant.id];
+  return {
+    variantId: variant.id,
+    status: reason ? "ALLOWLISTED" : "UNCLASSIFIED",
+    reason: reason ?? "Strict settlement policy is missing.",
+  };
+}
+
+function seatIndexOf(player, fallback) {
+  return player?.seatIndex ?? fallback;
+}
+
+function verifyNlhPotWinners(afterState, result) {
+  const errors = [];
+  const board = afterState?.boardCards ?? result?.board ?? [];
+  const players = afterState?.players ?? [];
+  const evaluations = players
+    .map((player, index) => ({
+      player,
+      seatIndex: seatIndexOf(player, index),
+      evaluation:
+        !player?.folded && !player?.seatOut && player?.holeCards?.length === 2 && board.length === 5
+          ? evaluateNlhHand({ cards: [...player.holeCards, ...board] })
+          : null,
+    }))
+    .filter((entry) => entry.evaluation);
+  const payouts = extractPayouts(result);
+
+  for (const [potIndex, pot] of (result?.potDetails ?? []).entries()) {
+    const eligible = new Set(pot.eligibleSeatIndexes ?? evaluations.map((entry) => entry.seatIndex));
+    const candidates = evaluations.filter((entry) => eligible.has(entry.seatIndex));
+    if (!candidates.length) {
+      errors.push({ code: "strict_nlh_pot_has_no_evaluable_player", potIndex });
+      continue;
+    }
+    const best = candidates.reduce((current, entry) =>
+      !current || compareNlhHands(entry.evaluation, current.evaluation) < 0 ? entry : current,
+    null);
+    const expected = candidates
+      .filter((entry) => compareNlhHands(entry.evaluation, best.evaluation) === 0)
+      .map((entry) => entry.seatIndex)
+      .sort((left, right) => left - right);
+    const actual = payouts
+      .filter((payout) => (payout.potIndex ?? 0) === potIndex && Number(payout.amount) > 0)
+      .map((payout) => payout.seatIndex)
+      .sort((left, right) => left - right);
+    if (JSON.stringify(actual) !== JSON.stringify(expected)) {
+      errors.push({ code: "strict_nlh_evaluator_winner_mismatch", potIndex, expected, actual });
+    }
+  }
+  return errors;
+}
+
+export function validateStrictVariantSettlement({
+  variantId,
+  beforeState,
+  afterState,
+  result = afterState?.lastHandResult,
+} = {}) {
+  const policy = getStrictSettlementPolicy(variantId);
+  if (policy.status !== "ENFORCED") {
+    return { ok: policy.status === "ALLOWLISTED", policy, errors: [], check: null };
+  }
+
+  const check = validateHandEvIntegrity({
+    beforeState,
+    afterState,
+    result,
+    variant: getVariantById(variantId),
+    options: {
+      requireResult: true,
+      strictChipConservation: true,
+      terminalPotIsResultEcho: true,
+    },
+  });
+  const strictErrors = [];
+  if (!Array.isArray(result?.potDetails) || result.potDetails.length === 0) {
+    strictErrors.push({ code: "strict_pot_details_missing" });
+  } else {
+    const detailsTotal = result.potDetails.reduce(
+      (sum, pot) => sum + Math.max(0, Number(pot?.amount ?? pot?.potAmount) || 0),
+      0,
+    );
+    if (detailsTotal !== Number(result.totalPot ?? result.pot ?? 0)) {
+      strictErrors.push({
+        code: "strict_pot_details_total_mismatch",
+        detailsTotal,
+        totalPot: Number(result.totalPot ?? result.pot ?? 0),
+      });
+    }
+  }
+  strictErrors.push(...verifyNlhPotWinners(afterState, result));
+  const errors = [...check.errors, ...strictErrors];
+  return { ok: errors.length === 0, policy, errors, check };
+}
+

--- a/src/games/testing/ev/strictVariantSettlementGate.test.js
+++ b/src/games/testing/ev/strictVariantSettlementGate.test.js
@@ -1,0 +1,78 @@
+import { describe, expect, it } from "vitest";
+import { GAME_VARIANTS } from "../../config/variantCatalog.js";
+import { NLHGameController } from "../../nlh/NLHGameController.js";
+import { createDeterministicRng } from "../deterministicRng.js";
+import {
+  STRICT_SETTLEMENT_ALLOWLIST,
+  getStrictSettlementPolicy,
+  validateStrictVariantSettlement,
+} from "./strictVariantSettlementGate.js";
+
+function seats() {
+  return Array.from({ length: 6 }, (_, seatIndex) => ({
+    seatIndex,
+    playerId: `p${seatIndex}`,
+    name: `P${seatIndex}`,
+    stack: 500,
+  }));
+}
+
+function playPassiveHand(controller) {
+  const beforeState = controller.startNewHand();
+  for (let step = 0; step < 100; step += 1) {
+    const snapshot = controller.getSnapshot();
+    if (snapshot.street === "SHOWDOWN") {
+      return { beforeState, afterState: snapshot };
+    }
+    const actor = snapshot.currentActor;
+    const player = snapshot.players[actor];
+    const toCall = Math.max(0, snapshot.currentBet - (player.betThisStreet ?? 0));
+    const action = toCall > 0 ? "call" : "check";
+    const outcome = controller.applyPlayerAction({ seatIndex: actor, action });
+    expect(outcome.success).toBe(true);
+  }
+  throw new Error("NLH passive hand did not terminate");
+}
+
+describe("strict per-variant settlement gate", () => {
+  it("classifies every non-pilot catalog variant with a documented reason", () => {
+    const policies = GAME_VARIANTS.map((variant) => getStrictSettlementPolicy(variant.id));
+    expect(policies.filter((policy) => policy.status === "ENFORCED").map((policy) => policy.variantId)).toEqual(["B01"]);
+    expect(policies.filter((policy) => policy.status === "UNCLASSIFIED")).toEqual([]);
+    expect(Object.keys(STRICT_SETTLEMENT_ALLOWLIST)).toHaveLength(35);
+    policies.filter((policy) => policy.status === "ALLOWLISTED").forEach((policy) => {
+      expect(policy.reason).toEqual(expect.any(String));
+      expect(policy.reason.length).toBeGreaterThan(30);
+    });
+  });
+
+  it("passes strict result, pot, evaluator, and chip conservation for seeded NLH", () => {
+    const controller = new NLHGameController({
+      tableConfig: { seats: seats(), blinds: { sb: 5, bb: 10, ante: 0 } },
+      rng: createDeterministicRng("strict-nlh-pilot"),
+    });
+    const hand = playPassiveHand(controller);
+    const gate = validateStrictVariantSettlement({ variantId: "B01", ...hand });
+    expect(gate.ok, JSON.stringify(gate.errors, null, 2)).toBe(true);
+  });
+
+  it("rejects a tampered NLH payout even when totals still add up", () => {
+    const controller = new NLHGameController({
+      tableConfig: { seats: seats(), blinds: { sb: 5, bb: 10, ante: 0 } },
+      rng: createDeterministicRng("strict-nlh-tamper"),
+    });
+    const hand = playPassiveHand(controller);
+    const result = structuredClone(hand.afterState.lastHandResult);
+    const actualWinner = result.winners[0].seatIndex;
+    const wrongWinner = (actualWinner + 1) % seats().length;
+    result.winners = result.winners.map((winner) => ({ ...winner, seatIndex: wrongWinner }));
+    result.potDetails = result.potDetails.map((pot) => ({
+      ...pot,
+      winners: pot.winners.map((winner) => ({ ...winner, seatIndex: wrongWinner })),
+      winnerSeatIndexes: [wrongWinner],
+    }));
+    const gate = validateStrictVariantSettlement({ variantId: "B01", ...hand, result });
+    expect(gate.ok).toBe(false);
+    expect(gate.errors.map((error) => error.code)).toContain("strict_nlh_evaluator_winner_mismatch");
+  });
+});

--- a/src/games/testing/scenario/multiHandProgression.test.js
+++ b/src/games/testing/scenario/multiHandProgression.test.js
@@ -1,0 +1,39 @@
+import { describe, expect, it } from "vitest";
+import { createProgressHarness, runProgressScenario, resolveScenarioHandCount, snapshotOf } from "./runProgressScenario.js";
+
+function dealtCards(snapshot) {
+  return {
+    board: snapshot.boardCards,
+    holes: snapshot.players.map((player) => player.holeCards ?? player.hand ?? []),
+  };
+}
+
+describe("deterministic real multi-hand progress scenarios", () => {
+  it("parses the requested hand count instead of treating it as a label", () => {
+    expect(resolveScenarioHandCount("cash-10-hands-smoke")).toBe(10);
+    expect(resolveScenarioHandCount("tournament-50-hands-smoke")).toBe(50);
+    expect(resolveScenarioHandCount("draw-count-full-cycle")).toBe(1);
+  });
+
+  it("injects a seed into the actual NLH deck shuffle", () => {
+    const first = snapshotOf(createProgressHarness("B01", { seed: "same-seed" }));
+    const second = snapshotOf(createProgressHarness("B01", { seed: "same-seed" }));
+    const different = snapshotOf(createProgressHarness("B01", { seed: "different-seed" }));
+    expect(dealtCards(first)).toEqual(dealtCards(second));
+    expect(dealtCards(first)).not.toEqual(dealtCards(different));
+  });
+
+  it("executes and strictly settles all ten NLH hands", () => {
+    const result = runProgressScenario({
+      variantId: "B01",
+      scenarioId: "cash-10-hands-smoke",
+      seed: "nlh-real-ten-hand",
+      maxSteps: 100,
+    });
+    expect(result.status).toBe("passed");
+    expect(result.handsCompleted).toBe(10);
+    expect(result.targetHandCount).toBe(10);
+    expect(result.strictSettlements).toHaveLength(10);
+    expect(result.strictSettlements.every((entry) => entry.status === "ENFORCED" && entry.ok)).toBe(true);
+  });
+});

--- a/src/games/testing/scenario/runOneHandProgression.js
+++ b/src/games/testing/scenario/runOneHandProgression.js
@@ -177,7 +177,10 @@ export async function runOneHandProgression({
     };
   }
 
-  const harness = createProgressHarness(variantId, { seatCount: playerCount ?? 6 });
+  const harness = createProgressHarness(variantId, {
+    seatCount: playerCount ?? 6,
+    seed,
+  });
   const beforeHandSnapshot = cloneSnapshot(snapshotOf(harness));
   const trace = [];
   let previousSignature = null;

--- a/src/games/testing/scenario/runProgressScenario.js
+++ b/src/games/testing/scenario/runProgressScenario.js
@@ -32,6 +32,10 @@ import RazzdugiGameDefinition from "../../stud/RazzdugiGameDefinition.js";
 import RazzduceyGameDefinition from "../../stud/RazzduceyGameDefinition.js";
 import { assertGameProgressInvariants, getActorIndex } from "../progress/gameProgressInvariants.js";
 import { chooseSafeAction } from "./safeActionPolicy.js";
+import { DeckManager } from "../../badugi/utils/deck.js";
+import { GAME_VARIANTS as CATALOG_VARIANTS } from "../../config/variantCatalog.js";
+import { createDeterministicRng } from "../deterministicRng.js";
+import { validateStrictVariantSettlement } from "../ev/strictVariantSettlementGate.js";
 
 const DEFAULT_SEATS = ["HUMAN", "CPU", "CPU", "CPU", "CPU", "CPU"];
 const DEFAULT_BLINDS = { sb: 10, bb: 20, ante: 0 };
@@ -148,11 +152,13 @@ export function getProgressHarnessStatus(variantId) {
 
 export function createProgressHarness(variantId, options = {}) {
   const normalizedVariantId = normalizeProgressVariantId(variantId);
+  const rng = createDeterministicRng(options.seed ?? `mgx-progress-${variantId}`);
   const seats = createProgressSeats({ count: options.seatCount ?? 6, stack: options.startingStack ?? 500 });
   if (BOARD_CONTROLLERS[normalizedVariantId]) {
     const Controller = BOARD_CONTROLLERS[normalizedVariantId];
     const controller = new Controller({
       tableConfig: { seats, blinds: { ...DEFAULT_BLINDS, ...(options.blinds ?? {}) } },
+      rng,
     });
     controller.startNewHand({ handId: `${normalizedVariantId}-progress-1` });
     return { family: "board", controller };
@@ -162,6 +168,7 @@ export function createProgressHarness(variantId, options = {}) {
       variant: normalizedVariantId,
       gameDefinition: STUD_DEFINITIONS[normalizedVariantId],
       tableConfig: { seats, blinds: { sb: 10, bb: 20, ante: 2, ...(options.blinds ?? {}) } },
+      rng,
     });
     controller.startNewHand({ handId: `${normalizedVariantId}-progress-1` });
     return { family: "stud", controller };
@@ -170,6 +177,7 @@ export function createProgressHarness(variantId, options = {}) {
     const controller = new DramahaGameController({
       variant: normalizedVariantId,
       tableConfig: { seats, blinds: { ...DEFAULT_BLINDS, ...(options.blinds ?? {}) } },
+      rng,
     });
     controller.startNewHand({ handId: `${normalizedVariantId}-progress-1` });
     return { family: "dramaha", controller };
@@ -196,6 +204,9 @@ export function createProgressHarness(variantId, options = {}) {
             structure: { ...DEFAULT_BLINDS, ...(options.blinds ?? {}) },
           },
         });
+    if (!isBadugi && controller.engine) {
+      controller.engine.deckManager = new DeckManager({ rng });
+    }
     let state = controller.createInitialState();
     state = controller.createNewHandState(state, {
       handId: `${normalizedVariantId}-progress-1`,
@@ -331,19 +342,25 @@ export function runProgressScenario({
   scenarioId = "cash-10-hands-smoke",
   seed = "mgx-progress-default",
   maxSteps = 160,
+  handCount = null,
   invariantContext = {},
 } = {}) {
   const status = getProgressHarnessStatus(variantId);
   if (!status.supported) {
     return { variantId, scenarioId, seed, status: "skipped", reason: status.reason };
   }
-  const harness = createProgressHarness(variantId);
+  const targetHandCount = handCount ?? resolveScenarioHandCount(scenarioId);
+  const harness = createProgressHarness(variantId, { seed });
   let repeated = 0;
   let previousSignature = null;
   const visited = [];
   const drawRoundIndexes = [];
+  const strictSettlements = [];
+  let handsCompleted = 0;
+  let handSteps = 0;
+  let beforeHandSnapshot = JSON.parse(JSON.stringify(snapshotOf(harness)));
 
-  for (let step = 0; step < maxSteps; step += 1) {
+  for (let step = 0; step < maxSteps * targetHandCount; step += 1) {
     const snapshot = snapshotOf(harness);
     const context = { variantId, scenarioId, seed, step, snapshot, ...invariantContext };
     assertGameProgressInvariants(snapshot, context);
@@ -352,7 +369,52 @@ export function runProgressScenario({
       drawRoundIndexes.push(Number(snapshot.drawRoundIndex ?? snapshot.drawRound ?? snapshot.metadata?.drawRoundIndex ?? 0));
     }
     if (isTerminal(snapshot)) {
-      return { variantId, scenarioId, seed, status: "passed", steps: step, visited, drawRoundIndexes };
+      handsCompleted += 1;
+      const catalogVariant = CATALOG_VARIANTS.find(
+        (variant) => variant.id === variantId || variant.engineKey === normalizeProgressVariantId(variantId),
+      );
+      if (catalogVariant) {
+        const strictGate = validateStrictVariantSettlement({
+          variantId: catalogVariant.id,
+          beforeState: beforeHandSnapshot,
+          afterState: snapshot,
+        });
+        strictSettlements.push({
+          hand: handsCompleted,
+          status: strictGate.policy.status,
+          reason: strictGate.policy.reason,
+          ok: strictGate.ok,
+        });
+        if (strictGate.policy.status === "ENFORCED" && !strictGate.ok) {
+          throw new Error(
+            `[MGX_STRICT_SETTLEMENT] ${JSON.stringify({
+              variantId: catalogVariant.id,
+              hand: handsCompleted,
+              errors: strictGate.errors,
+            })}`,
+          );
+        }
+      }
+      if (handsCompleted >= targetHandCount) {
+        return {
+          variantId,
+          scenarioId,
+          seed,
+          status: "passed",
+          steps: step,
+          handsCompleted,
+          targetHandCount,
+          visited,
+          drawRoundIndexes,
+          strictSettlements,
+        };
+      }
+      startNextHarnessHand(harness, { variantId, handNumber: handsCompleted + 1 });
+      beforeHandSnapshot = JSON.parse(JSON.stringify(snapshotOf(harness)));
+      repeated = 0;
+      previousSignature = null;
+      handSteps = 0;
+      continue;
     }
     const signature = buildSignature(snapshot);
     repeated = signature === previousSignature ? repeated + 1 : 0;
@@ -363,12 +425,49 @@ export function runProgressScenario({
       );
     }
     stepHarness(harness);
+    handSteps += 1;
+    if (handSteps >= maxSteps && !isTerminal(snapshotOf(harness))) {
+      throw new Error(
+        `[MGX_PROGRESS_TIMEOUT] per-hand maxSteps reached ${JSON.stringify(
+          describeFailure(snapshotOf(harness), {
+            variantId,
+            scenarioId,
+            seed,
+            hand: handsCompleted + 1,
+            maxSteps,
+          }),
+        )}`,
+      );
+    }
   }
   throw new Error(
     `[MGX_PROGRESS_TIMEOUT] maxSteps reached ${JSON.stringify(
       describeFailure(snapshotOf(harness), { variantId, scenarioId, seed, maxSteps }),
     )}`,
   );
+}
+
+export function resolveScenarioHandCount(scenarioId) {
+  const match = String(scenarioId ?? "").match(/(?:cash|tournament)-(\d+)-hands?/i);
+  return match ? Math.max(1, Number(match[1]) || 1) : 1;
+}
+
+function startNextHarnessHand(harness, { variantId, handNumber }) {
+  const snapshot = snapshotOf(harness);
+  if (harness.family === "draw") {
+    harness.state = harness.controller.createNewHandState(harness.state, {
+      handId: `${normalizeProgressVariantId(variantId)}-progress-${handNumber}`,
+      currentPlayers: snapshot.players,
+      dealerIndex:
+        typeof snapshot.dealerIndex === "number"
+          ? (snapshot.dealerIndex + 1) % Math.max(1, snapshot.players?.length ?? 1)
+          : undefined,
+    });
+    return snapshotOf(harness);
+  }
+  return harness.controller.startNewHand({
+    handId: `${normalizeProgressVariantId(variantId)}-progress-${handNumber}`,
+  });
 }
 
 export function buildSyntheticSnapshot(overrides = {}) {


### PR DESCRIPTION
## Summary
- validate the 36-game catalog against controllers, UI, availability and definitions
- make seeded progression actually deterministic and multi-hand
- add strict NLH settlement/chip-conservation gate and correct B01/B09 card counts

## Validation
- Tier1: 1,982 passed / 11 skipped
- game progress: 159 passed / 11 skipped
- one-hand: 53/53 passed
- build and focused lint passed