### PR TITLE
test(p2p): await websocket creation deterministically

### DIFF
--- a/src/ui/screens/__tests__/FriendMatchSetupScreen.test.jsx
+++ b/src/ui/screens/__tests__/FriendMatchSetupScreen.test.jsx
@@ -50,6 +50,10 @@ const room = {
 async function createAndOpen() {
   fireEvent.click(screen.getByRole("button", { name: /create room/i }));
   expect(await screen.findByText(/room created/i)).toBeTruthy();
+  await waitFor(() => {
+    expect(MockWebSocket.sockets).toHaveLength(1);
+    expect(MockWebSocket.sockets[0].listeners.open).toBeTypeOf("function");
+  });
   const socket = MockWebSocket.sockets.at(-1);
   await act(async () => socket.listeners.open());
   return socket;


### PR DESCRIPTION
Fixes the post-merge CI race where the room-created status could render before the WebSocket constructor ran. The helper now waits for both the socket and its open listener. Focused test passed 5 consecutive runs locally.