### PR TITLE
fix(deploy): discover active nginx site

### DIFF
--- a/scripts/deploy/ensure_mgx_nginx_websocket_proxy.sh
+++ b/scripts/deploy/ensure_mgx_nginx_websocket_proxy.sh
@@ -39,13 +39,37 @@ count_exact_lines() {
 
 snapshot="$(mktemp "${TMPDIR:-/tmp}/mgx-nginx-ws.XXXXXX")"
 candidate="$(mktemp "${TMPDIR:-/tmp}/mgx-nginx-ws-candidate.XXXXXX")"
+nginx_dump="$(mktemp "${TMPDIR:-/tmp}/mgx-nginx-dump.XXXXXX")"
 cleanup() {
-  rm -f -- "$snapshot" "$candidate"
+  rm -f -- "$snapshot" "$candidate" "$nginx_dump"
 }
 trap cleanup EXIT
 
-test -r "$SITE_PATH" || fail "active nginx site is not readable: $SITE_PATH"
-cat -- "$SITE_PATH" >"$snapshot"
+if ! run_sudo rsync -rL -- "$SITE_PATH" "$snapshot" 2>/dev/null; then
+  run_sudo "$NGINX_BIN" -T >"$nginx_dump" 2>&1 || fail "could not inspect active nginx configuration"
+  site_candidates="$(awk '
+    /^# configuration file / {
+      current = $0
+      sub(/^# configuration file /, "", current)
+      sub(/:$/, "", current)
+      next
+    }
+    /^[[:space:]]*server_name[[:space:]].*mgx-poker\.com.*;/ {
+      if (current != "") print current
+    }
+  ' "$nginx_dump" | sort -u)"
+  site_count="$(printf '%s\n' "$site_candidates" | awk 'NF { count++ } END { print count + 0 }')"
+  if [ "$site_count" -ne 1 ]; then
+    fail "expected exactly one active mgx-poker.com config file, found $site_count"
+  fi
+  SITE_PATH="$site_candidates"
+  run_sudo rsync -rL -- "$SITE_PATH" "$snapshot" || fail "could not read active nginx site: $SITE_PATH"
+fi
+
+resolved_site_path="$(readlink -f "$SITE_PATH" 2>/dev/null || true)"
+if [ -n "$resolved_site_path" ]; then
+  SITE_PATH="$resolved_site_path"
+fi
 
 server_name_count="$(count_exact_lines "^[[:space:]]*server_name[[:space:]].*mgx-poker\\.com.*;[[:space:]]*$" "$snapshot")"
 if [ "$server_name_count" -lt 1 ]; then
@@ -104,13 +128,13 @@ fi
 timestamp="$(date -u +%Y%m%dT%H%M%SZ).$$"
 backup_path="${BACKUP_DIR}/mgx-poker.com.${timestamp}.conf"
 run_sudo mkdir -p -- "$BACKUP_DIR"
-run_sudo rsync -a -- "$SITE_PATH" "$backup_path"
+run_sudo rsync -rL -- "$SITE_PATH" "$backup_path"
 chmod 0644 "$candidate"
-run_sudo rsync -a -- "$candidate" "$SITE_PATH"
+run_sudo rsync -r --inplace -- "$candidate" "$SITE_PATH"
 
 if ! run_sudo "$NGINX_BIN" -t; then
   echo "[mgx-nginx-ws] nginx validation failed; restoring $backup_path" >&2
-  run_sudo rsync -a -- "$backup_path" "$SITE_PATH"
+  run_sudo rsync -r --inplace -- "$backup_path" "$SITE_PATH"
   run_sudo "$NGINX_BIN" -t >/dev/null 2>&1 || true
   fail "candidate rejected by nginx; original site restored"
 fi

--- a/tests/scripts/test_ensure_mgx_nginx_websocket_proxy.sh
+++ b/tests/scripts/test_ensure_mgx_nginx_websocket_proxy.sh
@@ -43,6 +43,12 @@ set -euo pipefail
 test "$1" = "-n"
 shift
 if [ "$1" = "mock-nginx" ]; then
+  if [ "$2" = "-T" ]; then
+    test -n "${MGX_TEST_DISCOVERY_SITE:-}"
+    printf '# configuration file %s:\n' "$MGX_TEST_DISCOVERY_SITE"
+    cat "$MGX_TEST_DISCOVERY_SITE"
+    exit 0
+  fi
   test "$2" = "-t"
   result="$(cat "$MGX_TEST_NGINX_RESULT")"
   if [ "$result" = "fail-once" ]; then
@@ -58,11 +64,12 @@ chmod +x "$MOCK_SUDO"
 
 run_script() {
   MGX_NGINX_TEST_MODE=1 \
-    MGX_NGINX_SITE_PATH="$SITE" \
+    MGX_NGINX_SITE_PATH="${SITE_OVERRIDE:-$SITE}" \
     MGX_NGINX_BACKUP_DIR="$BACKUP_DIR" \
     MGX_NGINX_SUDO_BIN="$MOCK_SUDO" \
     MGX_NGINX_BIN="mock-nginx" \
     MGX_TEST_NGINX_RESULT="$NGINX_RESULT" \
+    MGX_TEST_DISCOVERY_SITE="${DISCOVERY_SITE:-}" \
     "$SCRIPT"
 }
 
@@ -81,6 +88,16 @@ test "$(grep -c 'location /ws/ {' "$SITE")" -eq 1 || fail "expected one WebSocke
 test "$(grep -c 'BEGIN MGX MANAGED P2P WEBSOCKET' "$SITE")" -eq 1 || fail "missing begin marker"
 backup_count="$(find "$BACKUP_DIR" -maxdepth 1 -name 'mgx-poker.com.*.conf' | wc -l | tr -d ' ')"
 test "$backup_count" -eq 1 || fail "expected one timestamp backup"
+
+rm -f -- "$BACKUP_DIR"/mgx-poker.com.*.conf
+write_base_site
+DISCOVERY_SITE="$TEST_DIR/custom-live-site.conf"
+mv -- "$SITE" "$DISCOVERY_SITE"
+SITE_OVERRIDE="$TEST_DIR/missing-site.conf"
+run_script
+test "$(grep -c 'location /ws/ {' "$DISCOVERY_SITE")" -eq 1 || fail "discovered site was not updated"
+unset DISCOVERY_SITE SITE_OVERRIDE
+cp -- "$TEST_DIR/custom-live-site.conf" "$SITE"
 
 before_noop="$(cksum "$SITE")"
 run_script


### PR DESCRIPTION
When the documented site path is absent or unreadable, derive the single active config containing server_name mgx-poker.com from nginx -T, copy it through the already-approved rsync command, resolve symlinks, and update in place. Adds a missing-path/custom-live-site regression test in addition to rollback and idempotency coverage.