### PR TITLE
fix(deploy): scan enabled nginx sites safely

### DIFF
--- a/scripts/deploy/ensure_mgx_nginx_websocket_proxy.sh
+++ b/scripts/deploy/ensure_mgx_nginx_websocket_proxy.sh
@@ -3,6 +3,7 @@
 set -euo pipefail
 
 readonly DEFAULT_SITE_PATH="/etc/nginx/sites-enabled/mgx-poker.com"
+readonly DEFAULT_ENABLED_DIR="/etc/nginx/sites-enabled"
 readonly DEFAULT_BACKUP_DIR="/var/backups/mgx-nginx"
 readonly BEGIN_MARKER="# BEGIN MGX MANAGED P2P WEBSOCKET"
 readonly END_MARKER="# END MGX MANAGED P2P WEBSOCKET"
@@ -14,15 +15,17 @@ fail() {
 
 if [ "${MGX_NGINX_TEST_MODE:-0}" = "1" ]; then
   SITE_PATH="${MGX_NGINX_SITE_PATH:-$DEFAULT_SITE_PATH}"
+  ENABLED_DIR="${MGX_NGINX_ENABLED_DIR:-$DEFAULT_ENABLED_DIR}"
   BACKUP_DIR="${MGX_NGINX_BACKUP_DIR:-$DEFAULT_BACKUP_DIR}"
   SUDO_BIN="${MGX_NGINX_SUDO_BIN:-sudo}"
   NGINX_BIN="${MGX_NGINX_BIN:-/usr/sbin/nginx}"
 else
   SITE_PATH="$DEFAULT_SITE_PATH"
+  ENABLED_DIR="$DEFAULT_ENABLED_DIR"
   BACKUP_DIR="$DEFAULT_BACKUP_DIR"
   SUDO_BIN="sudo"
   NGINX_BIN="/usr/sbin/nginx"
-  if [ -n "${MGX_NGINX_SITE_PATH:-}" ] || [ -n "${MGX_NGINX_BACKUP_DIR:-}" ] || [ -n "${MGX_NGINX_SUDO_BIN:-}" ] || [ -n "${MGX_NGINX_BIN:-}" ]; then
+  if [ -n "${MGX_NGINX_SITE_PATH:-}" ] || [ -n "${MGX_NGINX_ENABLED_DIR:-}" ] || [ -n "${MGX_NGINX_BACKUP_DIR:-}" ] || [ -n "${MGX_NGINX_SUDO_BIN:-}" ] || [ -n "${MGX_NGINX_BIN:-}" ]; then
     fail "path and command overrides are allowed only in test mode"
   fi
 fi
@@ -39,30 +42,21 @@ count_exact_lines() {
 
 snapshot="$(mktemp "${TMPDIR:-/tmp}/mgx-nginx-ws.XXXXXX")"
 candidate="$(mktemp "${TMPDIR:-/tmp}/mgx-nginx-ws-candidate.XXXXXX")"
-nginx_dump="$(mktemp "${TMPDIR:-/tmp}/mgx-nginx-dump.XXXXXX")"
+enabled_snapshot="$(mktemp -d "${TMPDIR:-/tmp}/mgx-nginx-enabled.XXXXXX")"
 cleanup() {
-  rm -f -- "$snapshot" "$candidate" "$nginx_dump"
+  rm -f -- "$snapshot" "$candidate"
+  rm -rf -- "$enabled_snapshot"
 }
 trap cleanup EXIT
 
 if ! run_sudo rsync -rL -- "$SITE_PATH" "$snapshot" 2>/dev/null; then
-  run_sudo "$NGINX_BIN" -T >"$nginx_dump" 2>&1 || fail "could not inspect active nginx configuration"
-  site_candidates="$(awk '
-    /^# configuration file / {
-      current = $0
-      sub(/^# configuration file /, "", current)
-      sub(/:$/, "", current)
-      next
-    }
-    /^[[:space:]]*server_name[[:space:]].*mgx-poker\.com.*;/ {
-      if (current != "") print current
-    }
-  ' "$nginx_dump" | sort -u)"
+  run_sudo rsync -rL -- "${ENABLED_DIR}/" "${enabled_snapshot}/" || fail "could not inspect enabled nginx sites"
+  site_candidates="$(grep -El '^[[:space:]]*server_name[[:space:]].*mgx-poker\.com.*;' "$enabled_snapshot"/* 2>/dev/null | sort -u || true)"
   site_count="$(printf '%s\n' "$site_candidates" | awk 'NF { count++ } END { print count + 0 }')"
   if [ "$site_count" -ne 1 ]; then
     fail "expected exactly one active mgx-poker.com config file, found $site_count"
   fi
-  SITE_PATH="$site_candidates"
+  SITE_PATH="${ENABLED_DIR}/${site_candidates#"${enabled_snapshot}"/}"
   run_sudo rsync -rL -- "$SITE_PATH" "$snapshot" || fail "could not read active nginx site: $SITE_PATH"
 fi
 

--- a/tests/scripts/test_ensure_mgx_nginx_websocket_proxy.sh
+++ b/tests/scripts/test_ensure_mgx_nginx_websocket_proxy.sh
@@ -43,12 +43,6 @@ set -euo pipefail
 test "$1" = "-n"
 shift
 if [ "$1" = "mock-nginx" ]; then
-  if [ "$2" = "-T" ]; then
-    test -n "${MGX_TEST_DISCOVERY_SITE:-}"
-    printf '# configuration file %s:\n' "$MGX_TEST_DISCOVERY_SITE"
-    cat "$MGX_TEST_DISCOVERY_SITE"
-    exit 0
-  fi
   test "$2" = "-t"
   result="$(cat "$MGX_TEST_NGINX_RESULT")"
   if [ "$result" = "fail-once" ]; then
@@ -65,11 +59,11 @@ chmod +x "$MOCK_SUDO"
 run_script() {
   MGX_NGINX_TEST_MODE=1 \
     MGX_NGINX_SITE_PATH="${SITE_OVERRIDE:-$SITE}" \
+    MGX_NGINX_ENABLED_DIR="${ENABLED_OVERRIDE:-$TEST_DIR/enabled}" \
     MGX_NGINX_BACKUP_DIR="$BACKUP_DIR" \
     MGX_NGINX_SUDO_BIN="$MOCK_SUDO" \
     MGX_NGINX_BIN="mock-nginx" \
     MGX_TEST_NGINX_RESULT="$NGINX_RESULT" \
-    MGX_TEST_DISCOVERY_SITE="${DISCOVERY_SITE:-}" \
     "$SCRIPT"
 }
 
@@ -91,13 +85,15 @@ test "$backup_count" -eq 1 || fail "expected one timestamp backup"
 
 rm -f -- "$BACKUP_DIR"/mgx-poker.com.*.conf
 write_base_site
-DISCOVERY_SITE="$TEST_DIR/custom-live-site.conf"
+mkdir -p -- "$TEST_DIR/enabled"
+DISCOVERY_SITE="$TEST_DIR/enabled/custom-live-site.conf"
 mv -- "$SITE" "$DISCOVERY_SITE"
 SITE_OVERRIDE="$TEST_DIR/missing-site.conf"
+ENABLED_OVERRIDE="$TEST_DIR/enabled"
 run_script
 test "$(grep -c 'location /ws/ {' "$DISCOVERY_SITE")" -eq 1 || fail "discovered site was not updated"
-unset DISCOVERY_SITE SITE_OVERRIDE
-cp -- "$TEST_DIR/custom-live-site.conf" "$SITE"
+unset DISCOVERY_SITE SITE_OVERRIDE ENABLED_OVERRIDE
+cp -- "$TEST_DIR/enabled/custom-live-site.conf" "$SITE"
 
 before_noop="$(cksum "$SITE")"
 run_script


### PR DESCRIPTION
Avoid nginx -T, which production sudo policy intentionally forbids. If the documented site filename is unavailable, copy only /etc/nginx/sites-enabled through the already-approved rsync command, require exactly one config with the MGX server_name, then update that resolved file with the existing backup/rollback checks. Discovery is covered by a custom enabled-site regression test.