### PR TITLE
feat(auth): add secure account deletion

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -99,6 +99,10 @@ Available endpoints (always safe, even without a DB):
 
 - `GET /api/health` – reports backend environment & DB reachability (`db: "ok"` or `"unreachable"`).
 - `GET /api/users` – placeholder users API that returns an empty list when the DB is offline.
+- `DELETE /api/auth/account` – permanently deletes the authenticated user after
+  current-password confirmation. It removes the user's tournament snapshot,
+  saved play-feedback payloads, and active P2P participation. Existing bearer
+  tokens stop working because the user record no longer exists.
 - `POST /api/badugi/rl/decision` – backend comparison fallback for Badugi RL schema v1. It accepts a 96-dim state vector + valid actions and responds with deterministic-safe action/scores while frontend ONNX remains the primary inference path.
 - `POST /api/badugi/hands` – validates Badugi hand-log payloads and persists them to the configured database (or returns `accepted:false` if the DB is unreachable).
 - `GET /api/badugi/hands/{hand_id}` – fetches a fully structured hand with actions/results.

--- a/backend/app/api/auth.py
+++ b/backend/app/api/auth.py
@@ -1,7 +1,10 @@
+import logging
 from datetime import timedelta
 
-from fastapi import APIRouter, Depends, HTTPException, status
-from pydantic import BaseModel, EmailStr
+from fastapi import APIRouter, Depends, HTTPException, Response, status
+from pydantic import BaseModel, EmailStr, Field
+from sqlalchemy import delete
+from sqlalchemy.exc import SQLAlchemyError
 from sqlalchemy.orm import Session
 
 from ..core.security import (
@@ -11,10 +14,11 @@ from ..core.security import (
 )
 from ..core.db import get_db
 from ..dependencies.auth import get_current_user
-from ..models import User
+from ..models import PlayFeedbackResult, TournamentSnapshot, User
 from ..schemas.user import UserPublic
 
 router = APIRouter(prefix="/auth", tags=["auth"])
+logger = logging.getLogger(__name__)
 
 
 class SignupRequest(BaseModel):
@@ -25,6 +29,10 @@ class SignupRequest(BaseModel):
 class LoginRequest(BaseModel):
     email: EmailStr
     password: str
+
+
+class DeleteAccountRequest(BaseModel):
+    password: str = Field(..., min_length=1, max_length=1024)
 
 
 # NOTE: /auth/signup returns a minimal acknowledgement payload so the client
@@ -82,3 +90,59 @@ def read_current_user(current_user: User = Depends(get_current_user)):
 @router.post("/logout")
 def logout(_: User = Depends(get_current_user)):
     return {"ok": True}
+
+
+@router.delete("/account")
+async def delete_account(
+    payload: DeleteAccountRequest,
+    response: Response,
+    current_user: User = Depends(get_current_user),
+    db: Session = Depends(get_db),
+):
+    """Permanently delete the authenticated account and linked private data."""
+
+    response.headers["Cache-Control"] = "private, no-store"
+    response.headers["Pragma"] = "no-cache"
+    if not verify_password(payload.password, current_user.hashed_password):
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="invalid_password",
+            headers={
+                "Cache-Control": "private, no-store",
+                "Pragma": "no-cache",
+            },
+        )
+
+    user_id = current_user.id
+    try:
+        db.execute(
+            delete(TournamentSnapshot).where(TournamentSnapshot.user_id == user_id),
+        )
+        # Feedback payloads are removed instead of anonymized because they can
+        # contain user-provided hand context even when the top-level flag says
+        # PII was stripped.
+        db.execute(
+            delete(PlayFeedbackResult).where(PlayFeedbackResult.user_id == user_id),
+        )
+        db.delete(current_user)
+        db.commit()
+    except SQLAlchemyError as exc:
+        db.rollback()
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail="account_deletion_failed",
+        ) from exc
+
+    # Import lazily to avoid coupling authentication module initialization to
+    # the P2P router. The database deletion remains authoritative even if no
+    # process-local room exists.
+    from .p2p import terminate_user_p2p_sessions
+
+    try:
+        await terminate_user_p2p_sessions(str(user_id))
+    except Exception:
+        # The account and private persisted data are already deleted. A stale
+        # process-local room must not turn a successful permanent deletion into
+        # a misleading error response.
+        logger.exception("Failed to terminate P2P state for deleted user %s", user_id)
+    return {"deleted": True}

--- a/backend/app/api/p2p.py
+++ b/backend/app/api/p2p.py
@@ -416,6 +416,23 @@ class RoomSockets:
 room_sockets = RoomSockets()
 
 
+async def terminate_user_p2p_sessions(user_id: str) -> None:
+    """Remove a deleted account from all process-local rooms and sockets."""
+
+    for room_code in p2p_room_manager.room_codes_for_user(user_id):
+        try:
+            room = p2p_room_manager.leave_room(room_code, user_id=user_id)
+        except P2PError as exc:
+            if exc.code == "room_missing":
+                continue
+            raise
+        await room_sockets.close_user(room_code, user_id, reason="account_deleted")
+        if room is None:
+            await room_sockets.close_room(room_code, reason="owner_account_deleted")
+        else:
+            await room_sockets.broadcast_state(room)
+
+
 async def _send_error(
     websocket: WebSocket,
     exc: P2PError,

--- a/backend/app/p2p/manager.py
+++ b/backend/app/p2p/manager.py
@@ -123,6 +123,17 @@ class P2PRoomManager:
         with self._lock:
             self._rooms.clear()
 
+    def room_codes_for_user(self, user_id: str) -> list[str]:
+        """Return active room codes containing a user."""
+
+        with self._lock:
+            self._prune_expired_rooms()
+            return [
+                room.code
+                for room in self._rooms.values()
+                if not room.closed and user_id in room.players
+            ]
+
     def create_room(
         self,
         *,

--- a/backend/tests/test_account_deletion.py
+++ b/backend/tests/test_account_deletion.py
@@ -1,0 +1,170 @@
+from fastapi.testclient import TestClient
+from sqlalchemy import create_engine, select
+from sqlalchemy.orm import close_all_sessions, sessionmaker
+from sqlalchemy.pool import StaticPool
+
+from app.core import db
+from app.main import app
+from app.models import Base, PlayFeedbackResult, TournamentSnapshot, User
+from app.p2p.manager import p2p_room_manager
+
+
+PASSWORD = "Delete-Me-2026!"
+
+
+def _setup_database(monkeypatch):
+    engine = create_engine(
+        "sqlite+pysqlite://",
+        future=True,
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    Base.metadata.create_all(bind=engine)
+    session_factory = sessionmaker(
+        bind=engine,
+        autoflush=False,
+        autocommit=False,
+        future=True,
+    )
+    monkeypatch.setattr(db, "engine", engine)
+    monkeypatch.setattr(db, "SessionLocal", session_factory)
+    return engine, session_factory
+
+
+def _signup_and_login(client: TestClient, email: str) -> str:
+    signup = client.post(
+        "/api/auth/signup",
+        json={"email": email, "password": PASSWORD},
+    )
+    assert signup.status_code == 201
+    login = client.post(
+        "/api/auth/login",
+        json={"email": email, "password": PASSWORD},
+    )
+    assert login.status_code == 200
+    return login.json()["access_token"]
+
+
+def _auth(token: str) -> dict[str, str]:
+    return {"Authorization": f"Bearer {token}"}
+
+
+def test_delete_account_requires_current_password_and_removes_linked_data(monkeypatch):
+    engine, session_factory = _setup_database(monkeypatch)
+    client = TestClient(app)
+    host_email = "delete-host@example.com"
+    guest_email = "delete-guest@example.com"
+    try:
+        host_token = _signup_and_login(client, host_email)
+        guest_token = _signup_and_login(client, guest_email)
+
+        created = client.post(
+            "/api/p2p/rooms",
+            headers=_auth(host_token),
+            json={"variantId": "badugi"},
+        )
+        assert created.status_code == 200
+        room_code = created.json()["roomCode"]
+        assert client.post(
+            "/api/p2p/rooms/join",
+            headers=_auth(guest_token),
+            json={"roomCode": room_code},
+        ).status_code == 200
+
+        with session_factory() as session:
+            host = session.execute(
+                select(User).where(User.email == host_email),
+            ).scalar_one()
+            host_id = host.id
+            session.add(
+                TournamentSnapshot(
+                    user_id=host_id,
+                    snapshot={"tournamentId": "delete-me"},
+                ),
+            )
+            session.add(
+                PlayFeedbackResult(
+                    user_id=host_id,
+                    session_key="delete-me",
+                    mode="tournament",
+                    variant_scope="badugi",
+                    tournament_id="delete-me",
+                    hand_count=1,
+                    source="fallback",
+                    pii_removed=True,
+                    payload={"private": "context"},
+                    response={"summary": "private"},
+                ),
+            )
+            session.commit()
+
+        wrong_password = client.request(
+            "DELETE",
+            "/api/auth/account",
+            headers=_auth(host_token),
+            json={"password": "wrong-password"},
+        )
+        assert wrong_password.status_code == 403
+        assert wrong_password.json()["detail"] == "invalid_password"
+        assert wrong_password.headers["cache-control"] == "private, no-store"
+        assert client.get("/api/auth/me", headers=_auth(host_token)).status_code == 200
+
+        empty_password = client.request(
+            "DELETE",
+            "/api/auth/account",
+            headers=_auth(host_token),
+            json={"password": ""},
+        )
+        assert empty_password.status_code == 422
+
+        deleted = client.request(
+            "DELETE",
+            "/api/auth/account",
+            headers=_auth(host_token),
+            json={"password": PASSWORD},
+        )
+        assert deleted.status_code == 200
+        assert deleted.json() == {"deleted": True}
+        assert deleted.headers["cache-control"] == "private, no-store"
+        assert deleted.headers["pragma"] == "no-cache"
+
+        with session_factory() as session:
+            assert session.get(User, host_id) is None
+            assert session.scalar(
+                select(TournamentSnapshot).where(TournamentSnapshot.user_id == host_id),
+            ) is None
+            assert session.scalar(
+                select(PlayFeedbackResult).where(PlayFeedbackResult.user_id == host_id),
+            ) is None
+
+        assert client.get("/api/auth/me", headers=_auth(host_token)).status_code == 401
+        assert client.get(
+            f"/api/p2p/rooms/{room_code}/state",
+            headers=_auth(guest_token),
+        ).status_code == 404
+        assert p2p_room_manager.room_codes_for_user(str(host_id)) == []
+
+        # The deleted identity no longer reserves its email address.
+        assert client.post(
+            "/api/auth/signup",
+            json={"email": host_email, "password": PASSWORD},
+        ).status_code == 201
+    finally:
+        p2p_room_manager.reset()
+        app.dependency_overrides.clear()
+        close_all_sessions()
+        engine.dispose()
+
+
+def test_delete_account_requires_authentication(monkeypatch):
+    engine, _ = _setup_database(monkeypatch)
+    try:
+        response = TestClient(app).request(
+            "DELETE",
+            "/api/auth/account",
+            json={"password": PASSWORD},
+        )
+        assert response.status_code == 401
+    finally:
+        close_all_sessions()
+        engine.dispose()

--- a/docs/development/dev-setup.md
+++ b/docs/development/dev-setup.md
@@ -68,6 +68,7 @@ Frontend calls these routes via `/api/*`:
 - `/api/auth/login`
 - `/api/auth/me`
 - `/api/auth/logout`
+- `/api/auth/account` (`DELETE`, bearer token and current password required)
 - `/api/badugi/hands`
 - `/api/badugi/hands/recent`
 - `/api/tournament/save`


### PR DESCRIPTION
## Summary
- add `DELETE /api/auth/account` with bearer authentication and current-password confirmation
- delete the user, tournament snapshot, and saved play-feedback payloads in one database transaction
- terminate active P2P rooms/sockets after deletion and invalidate existing JWTs through user removal
- return private no-store responses and preserve the account if password verification or database deletion fails

## Verification
- full backend suite: 58 passed
- wrong/empty password does not delete
- linked private data is removed
- old bearer token returns 401
- active owner room closes for the guest
- deleted email can be registered again
- Python compile and diff check passed