### PR TITLE
test(tournament): tolerate bounded CPU phase transitions

### DIFF
--- a/tests/e2e/helpers/gameProgressHelper.js
+++ b/tests/e2e/helpers/gameProgressHelper.js
@@ -306,6 +306,23 @@ export async function performSafeAction(page, options = {}) {
     return { acted: false, reason: "terminal", before: summarizeProgressState(progress) };
   }
   if (typeof actor !== "number") {
+    // Between a CPU action and the next street/actor assignment the app can
+    // briefly publish a non-terminal BET/DRAW snapshot with no actor. Treat
+    // that as an asynchronous transition, but keep the bounded timeout so a
+    // genuine null-actor freeze still fails the progression gate.
+    if (BET_PHASES.has(phase) || DRAW_PHASES.has(phase)) {
+      const changed = await waitForProgressChange(page, beforeKey, { timeout: 3000 })
+        .then(() => true)
+        .catch(() => false);
+      if (changed) {
+        return {
+          acted: true,
+          clickedAction: "auto-transition",
+          actor: null,
+          before: summarizeProgressState(progress),
+        };
+      }
+    }
     return { acted: false, reason: "no-actor", before: summarizeProgressState(progress) };
   }
 


### PR DESCRIPTION
## Summary
- treat the brief no-actor window between CPU action and phase assignment as an asynchronous transition
- wait at most 3 seconds, preserving the existing fatal failure for a genuine null-actor freeze

## Evidence
- reproduced the workflow failure at Store hand 48 / final draw
- full tournament PR E2E: 10/10 passed
- Store production-field champion test: 3 additional passes
- focused eslint and diff check passed