### PR TITLE
Complete MGX quality program and release gates

### DIFF
--- a/.github/workflows/deploy-mgx-prod-01.yml
+++ b/.github/workflows/deploy-mgx-prod-01.yml
@@ -30,6 +30,7 @@ jobs:
       - run: npm run lint
       - run: npm run build
       - run: npm run test:tier1
+      - run: npm run test:deploy:static
 
   backend:
     runs-on: ubuntu-latest

--- a/.github/workflows/deploy-mgx-prod-01.yml
+++ b/.github/workflows/deploy-mgx-prod-01.yml
@@ -30,6 +30,8 @@ jobs:
       - run: npm run lint
       - run: npm run build
       - run: npm run test:tier1
+      - run: npm run test:game:progress
+      - run: npm run test:game:ev
       - run: npm run test:deploy:static
 
   backend:

--- a/backend/alembic/versions/20260827_01_add_p2p_room_states.py
+++ b/backend/alembic/versions/20260827_01_add_p2p_room_states.py
@@ -1,0 +1,33 @@
+"""add durable p2p room states
+
+Revision ID: 20260827_01
+Revises: 20260504_01
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+revision = "20260827_01"
+down_revision = "20260504_01"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "p2p_room_states",
+        sa.Column("room_code", sa.String(length=12), primary_key=True),
+        sa.Column("owner_id", sa.String(length=64), nullable=False),
+        sa.Column("sequence_id", sa.Integer(), nullable=False, server_default="0"),
+        sa.Column("closed", sa.Boolean(), nullable=False, server_default=sa.text("0")),
+        sa.Column("snapshot", sa.JSON(), nullable=False),
+        sa.Column("updated_at", sa.DateTime(), nullable=False, server_default=sa.func.now()),
+    )
+    op.create_index("ix_p2p_room_states_owner_id", "p2p_room_states", ["owner_id"])
+    op.create_index("ix_p2p_room_states_updated_at", "p2p_room_states", ["updated_at"])
+
+
+def downgrade() -> None:
+    op.drop_index("ix_p2p_room_states_updated_at", table_name="p2p_room_states")
+    op.drop_index("ix_p2p_room_states_owner_id", table_name="p2p_room_states")
+    op.drop_table("p2p_room_states")

--- a/backend/alembic/versions/20260828_01_reconcile_core_tables.py
+++ b/backend/alembic/versions/20260828_01_reconcile_core_tables.py
@@ -1,0 +1,122 @@
+"""reconcile legacy core tables for clean database installs
+
+Revision ID: 20260828_01
+Revises: 20260827_01
+Create Date: 2026-08-28 00:00:00.000000
+
+The original users and hand-history tables predate the Alembic chain. Existing
+production databases already contain them, while a clean ``upgrade head`` did
+not. This migration creates only tables that are absent so it is safe for both
+database histories.
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision = "20260828_01"
+down_revision = "20260827_01"
+branch_labels = None
+depends_on = None
+
+
+def _has_table(name: str) -> bool:
+    return sa.inspect(op.get_bind()).has_table(name)
+
+
+def upgrade() -> None:
+    if not _has_table("users"):
+        op.create_table(
+            "users",
+            sa.Column("id", sa.Integer(), primary_key=True, autoincrement=True),
+            sa.Column("name", sa.String(length=255), nullable=True),
+            sa.Column("email", sa.String(length=255), nullable=False),
+            sa.Column("hashed_password", sa.String(length=255), nullable=False),
+            sa.Column("created_at", sa.DateTime(), nullable=False, server_default=sa.func.now()),
+            sa.Column("updated_at", sa.DateTime(), nullable=False, server_default=sa.func.now()),
+            sa.UniqueConstraint("email", name="uq_users_email"),
+        )
+        op.create_index("ix_users_email", "users", ["email"], unique=True)
+
+    hand_id_type = sa.BigInteger().with_variant(sa.Integer(), "sqlite")
+    if not _has_table("badugi_hand_logs"):
+        op.create_table(
+            "badugi_hand_logs",
+            sa.Column("id", hand_id_type, primary_key=True, autoincrement=True),
+            sa.Column("hand_id", sa.String(length=64), nullable=False),
+            sa.Column("table_id", sa.String(length=64), nullable=True),
+            sa.Column("tournament_id", sa.String(length=64), nullable=True),
+            sa.Column("level", sa.Integer(), nullable=True),
+            sa.Column("created_at", sa.DateTime(timezone=True), nullable=False, server_default=sa.func.now()),
+            sa.Column("metadata", sa.JSON(), nullable=True),
+            sa.UniqueConstraint("hand_id", name="uq_badugi_hand_logs_hand_id"),
+        )
+        op.create_index("ix_badugi_hand_logs_hand_id", "badugi_hand_logs", ["hand_id"], unique=True)
+        op.create_index("ix_badugi_hand_logs_table_id", "badugi_hand_logs", ["table_id"])
+        op.create_index("ix_badugi_hand_logs_tournament_id", "badugi_hand_logs", ["tournament_id"])
+
+    if not _has_table("badugi_hand_actions"):
+        op.create_table(
+            "badugi_hand_actions",
+            sa.Column("id", hand_id_type, primary_key=True, autoincrement=True),
+            sa.Column(
+                "hand_log_id",
+                hand_id_type,
+                sa.ForeignKey("badugi_hand_logs.id", ondelete="CASCADE"),
+                nullable=False,
+            ),
+            sa.Column("seat_index", sa.Integer(), nullable=False),
+            sa.Column("player_id", sa.String(length=64), nullable=True),
+            sa.Column("action", sa.String(length=32), nullable=False),
+            sa.Column("amount", sa.Integer(), nullable=True),
+            sa.Column("round", sa.Integer(), nullable=False),
+            sa.Column("phase", sa.String(length=32), nullable=False),
+        )
+        op.create_index("ix_badugi_hand_actions_hand_log_id", "badugi_hand_actions", ["hand_log_id"])
+
+    if not _has_table("badugi_hand_results"):
+        op.create_table(
+            "badugi_hand_results",
+            sa.Column("id", hand_id_type, primary_key=True, autoincrement=True),
+            sa.Column(
+                "hand_log_id",
+                hand_id_type,
+                sa.ForeignKey("badugi_hand_logs.id", ondelete="CASCADE"),
+                nullable=False,
+            ),
+            sa.Column("seat_index", sa.Integer(), nullable=False),
+            sa.Column("player_id", sa.String(length=64), nullable=True),
+            sa.Column("final_stack", sa.Integer(), nullable=False),
+            sa.Column("hand_label", sa.String(length=128), nullable=True),
+            sa.Column("is_winner", sa.Boolean(), nullable=False, server_default=sa.false()),
+            sa.Column("pot_share", sa.Integer(), nullable=False),
+        )
+        op.create_index("ix_badugi_hand_results_hand_log_id", "badugi_hand_results", ["hand_log_id"])
+
+    # Revision 20260212_01 used BIGINT for this autoincrement key. SQLite only
+    # autoincrements a column declared exactly INTEGER PRIMARY KEY, so clean
+    # test/dev installs could read the table but every telemetry insert failed.
+    # Production MySQL keeps its BIGINT unchanged.
+    bind = op.get_bind()
+    if bind.dialect.name == "sqlite" and _has_table("badugi_action_logs"):
+        id_column = next(
+            column
+            for column in sa.inspect(bind).get_columns("badugi_action_logs")
+            if column["name"] == "id"
+        )
+        if isinstance(id_column["type"], sa.BigInteger):
+            with op.batch_alter_table("badugi_action_logs", recreate="always") as batch_op:
+                batch_op.alter_column(
+                    "id",
+                    existing_type=sa.BigInteger(),
+                    type_=sa.Integer(),
+                    existing_nullable=False,
+                    autoincrement=True,
+                )
+
+
+def downgrade() -> None:
+    # These tables can predate Alembic in production. Dropping them would risk
+    # deleting user accounts and hand history, so this reconciliation is
+    # intentionally non-destructive on downgrade.
+    pass

--- a/backend/app/api/p2p.py
+++ b/backend/app/api/p2p.py
@@ -148,6 +148,7 @@ def _http_error(exc: P2PError) -> HTTPException:
         "active_room_limit": status.HTTP_409_CONFLICT,
         "stale_command": status.HTTP_409_CONFLICT,
         "command_conflict": status.HTTP_409_CONFLICT,
+        "state_conflict": status.HTTP_409_CONFLICT,
     }
     return HTTPException(
         status_code=code_to_status.get(exc.code, status.HTTP_400_BAD_REQUEST),

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -20,7 +20,8 @@ from .api.auth import router as auth_router
 from .api.variants import router as variants_router
 from .api.p2p import router as p2p_router, ws_router as p2p_ws_router
 from .core.config import get_settings
-from .core.db import engine
+from .core.db import SessionLocal, engine
+from .p2p.manager import p2p_room_manager
 
 
 settings = get_settings()
@@ -94,6 +95,20 @@ def _assert_migrations_up_to_date() -> None:
 
 app = FastAPI(title="Badugi Multi-Game Backend", version="0.1.0")
 app.add_event_handler("startup", bootstrap_schema)
+
+
+def configure_p2p_persistence() -> None:
+    """Enable durable room recovery outside isolated test runs."""
+
+    if (settings.backend_env or "local").lower() == "test":
+        p2p_room_manager.attach_store(None)
+        return
+    from .p2p.persistence import SQLAlchemyRoomStore
+
+    p2p_room_manager.attach_store(SQLAlchemyRoomStore(SessionLocal))
+
+
+app.add_event_handler("startup", configure_p2p_persistence)
 
 app.add_middleware(
     CORSMiddleware,

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -13,6 +13,7 @@ from .hand_log import HandAction, HandLog, HandResult  # noqa: E402
 from .badugi_action_log import BadugiHandAction  # noqa: E402
 from .tournament_snapshot import TournamentSnapshot  # noqa: E402
 from .play_feedback import PlayFeedbackResult  # noqa: E402
+from .p2p_room_state import P2PRoomState  # noqa: E402
 from .variant import (  # noqa: E402
     Variant,
     VariantBettingStructure,
@@ -31,6 +32,7 @@ __all__ = (
     "BadugiHandAction",
     "TournamentSnapshot",
     "PlayFeedbackResult",
+    "P2PRoomState",
     "Variant",
     "VariantRule",
     "VariantModifier",

--- a/backend/app/models/p2p_room_state.py
+++ b/backend/app/models/p2p_room_state.py
@@ -1,0 +1,24 @@
+"""Durable server-authoritative Friend Match room snapshots."""
+from datetime import datetime
+
+from sqlalchemy import Boolean, DateTime, JSON, String, func
+from sqlalchemy.orm import Mapped, mapped_column
+
+from . import Base
+
+
+class P2PRoomState(Base):
+    __tablename__ = "p2p_room_states"
+
+    room_code: Mapped[str] = mapped_column(String(12), primary_key=True)
+    owner_id: Mapped[str] = mapped_column(String(64), nullable=False, index=True)
+    sequence_id: Mapped[int] = mapped_column(nullable=False, default=0)
+    closed: Mapped[bool] = mapped_column(Boolean, nullable=False, default=False)
+    snapshot: Mapped[dict] = mapped_column(JSON, nullable=False)
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime,
+        server_default=func.now(),
+        onupdate=func.now(),
+        nullable=False,
+        index=True,
+    )

--- a/backend/app/p2p/manager.py
+++ b/backend/app/p2p/manager.py
@@ -1,9 +1,4 @@
-"""In-memory, server-authoritative heads-up Badugi friend matches.
-
-The runtime intentionally supports one well-defined game before advertising
-the wider MGX catalogue.  Rooms survive browser reconnects, but not a backend
-restart; durable room persistence is a separate production-scaling concern.
-"""
+"""Server-authoritative, durably persisted heads-up Badugi friend matches."""
 from __future__ import annotations
 
 from copy import deepcopy
@@ -41,6 +36,7 @@ class RoomStore(Protocol):
     def delete(self, room_code: str) -> None: ...
     def room_codes_for_user(self, user_id: str) -> list[str]: ...
     def active_owner_count(self, user_id: str) -> int: ...
+    def prune_expired(self, cutoff_timestamp: float) -> int: ...
 
 
 def _rank_value(card: str) -> int:
@@ -509,6 +505,8 @@ class P2PRoomManager:
 
     def _prune_expired_rooms(self) -> None:
         now = time.time()
+        if self._store:
+            self._store.prune_expired(now - ROOM_TTL_SECONDS)
         expired = [
             code
             for code, room in self._rooms.items()

--- a/backend/app/p2p/manager.py
+++ b/backend/app/p2p/manager.py
@@ -13,7 +13,7 @@ import secrets
 import string
 import threading
 import time
-from typing import Any
+from typing import Any, Protocol
 
 
 RANKS = "A23456789TJQK"
@@ -32,6 +32,15 @@ class P2PError(RuntimeError):
     def __init__(self, code: str, message: str):
         super().__init__(message)
         self.code = code
+
+
+class RoomStore(Protocol):
+    def load(self, room_code: str) -> "Room | None": ...
+    def exists(self, room_code: str) -> bool: ...
+    def save(self, room: "Room") -> bool: ...
+    def delete(self, room_code: str) -> None: ...
+    def room_codes_for_user(self, user_id: str) -> list[str]: ...
+    def active_owner_count(self, user_id: str) -> int: ...
 
 
 def _rank_value(card: str) -> int:
@@ -118,6 +127,24 @@ class P2PRoomManager:
         self._rooms: dict[str, Room] = {}
         self._lock = threading.RLock()
         self._rng = secrets.SystemRandom()
+        self._store: RoomStore | None = None
+
+    def attach_store(self, store: RoomStore | None) -> None:
+        with self._lock:
+            self._store = store
+
+    def _persist(self, room: Room) -> None:
+        if not self._store:
+            return
+        if self._store.save(room):
+            return
+        latest = self._store.load(room.code)
+        if latest is not None:
+            self._rooms[room.code] = latest
+        raise P2PError(
+            "state_conflict",
+            "Room state changed on another server; retry with the latest sequence",
+        )
 
     def reset(self) -> None:
         with self._lock:
@@ -128,11 +155,14 @@ class P2PRoomManager:
 
         with self._lock:
             self._prune_expired_rooms()
-            return [
+            codes = {
                 room.code
                 for room in self._rooms.values()
                 if not room.closed and user_id in room.players
-            ]
+            }
+            if self._store:
+                codes.update(self._store.room_codes_for_user(user_id))
+            return sorted(codes)
 
     def create_room(
         self,
@@ -155,6 +185,8 @@ class P2PRoomManager:
                 for room in self._rooms.values()
                 if room.owner_id == user_id and not room.closed
             )
+            if self._store:
+                owner_room_count = max(owner_room_count, self._store.active_owner_count(user_id))
             if owner_room_count >= MAX_ACTIVE_ROOMS_PER_OWNER:
                 raise P2PError(
                     "active_room_limit",
@@ -171,6 +203,7 @@ class P2PRoomManager:
             )
             room.players[user_id] = Player(user_id, display_name, 0, starting_stack)
             self._rooms[code] = room
+            self._persist(room)
             return room
 
     def get_room(self, code: str) -> Room:
@@ -178,6 +211,11 @@ class P2PRoomManager:
         with self._lock:
             self._prune_expired_rooms()
             room = self._rooms.get(normalized)
+            if self._store:
+                persisted = self._store.load(normalized)
+                if persisted and (room is None or persisted.sequence_id > room.sequence_id):
+                    room = persisted
+                    self._rooms[normalized] = room
             if not room or room.closed:
                 raise P2PError("room_missing", "Room not found")
             return room
@@ -186,12 +224,16 @@ class P2PRoomManager:
         with self._lock:
             room = self.get_room(code)
             if user_id in room.players:
-                room.players[user_id].display_name = display_name
+                if room.players[user_id].display_name != display_name:
+                    room.players[user_id].display_name = display_name
+                    self._record(room, "player_profile_updated", user_id=user_id)
+                    self._persist(room)
                 return room
             if len(room.players) >= 2 or room.phase != "waiting":
                 raise P2PError("room_unavailable", "Room is full or already playing")
             room.players[user_id] = Player(user_id, display_name, 1, room.starting_stack)
             self._record(room, "player_joined", user_id=user_id)
+            self._persist(room)
             return room
 
     def leave_room(self, code: str, *, user_id: str) -> Room | None:
@@ -207,8 +249,11 @@ class P2PRoomManager:
             self._record(room, "player_left", user_id=user_id)
             if not room.players or user_id == room.owner_id:
                 room.closed = True
+                self._record(room, "room_closed", user_id=user_id)
+                self._persist(room)
                 return None
             room.phase = "waiting"
+            self._persist(room)
             return room
 
     def set_connected(self, code: str, *, user_id: str, connected: bool) -> Room:
@@ -217,9 +262,10 @@ class P2PRoomManager:
             player = self._player(room, user_id)
             player.connected = connected
             self._bump(room)
+            self._persist(room)
             return room
 
-    def ready(self, code: str, *, user_id: str) -> Room:
+    def ready(self, code: str, *, user_id: str, persist: bool = True) -> Room:
         with self._lock:
             room = self.get_room(code)
             if room.phase not in {"waiting", "showdown"}:
@@ -229,9 +275,11 @@ class P2PRoomManager:
             self._record(room, "ready", user_id=user_id)
             if len(room.players) == 2 and all(player.ready for player in room.players.values()):
                 self._start_hand(room)
+            if persist:
+                self._persist(room)
             return room
 
-    def act(self, code: str, *, user_id: str, action: str, amount: int = 0) -> Room:
+    def act(self, code: str, *, user_id: str, action: str, amount: int = 0, persist: bool = True) -> Room:
         with self._lock:
             room = self.get_room(code)
             player = self._player(room, user_id)
@@ -253,6 +301,8 @@ class P2PRoomManager:
                     winner_ids=[opponent.user_id] if opponent else [],
                     reason="fold",
                 )
+                if persist:
+                    self._persist(room)
                 return room
             if action == "check":
                 paid = 0
@@ -279,9 +329,11 @@ class P2PRoomManager:
             else:
                 room.current_actor_id = self._other_player(room, user_id).user_id
                 self._bump(room)
+            if persist:
+                self._persist(room)
             return room
 
-    def draw(self, code: str, *, user_id: str, card_indexes: list[int]) -> Room:
+    def draw(self, code: str, *, user_id: str, card_indexes: list[int], persist: bool = True) -> Room:
         with self._lock:
             room = self.get_room(code)
             player = self._player(room, user_id)
@@ -306,6 +358,8 @@ class P2PRoomManager:
             else:
                 room.current_actor_id = next(iter(room.pending_draw))
                 self._bump(room)
+            if persist:
+                self._persist(room)
             return room
 
     def execute_command(
@@ -355,19 +409,21 @@ class P2PRoomManager:
                 )
 
             if normalized_type == "ready":
-                room = self.ready(room.code, user_id=user_id)
+                room = self.ready(room.code, user_id=user_id, persist=False)
             elif normalized_type == "action":
                 room = self.act(
                     room.code,
                     user_id=user_id,
                     action=normalized_action,
                     amount=amount,
+                    persist=False,
                 )
             elif normalized_type == "draw":
                 room = self.draw(
                     room.code,
                     user_id=user_id,
                     card_indexes=list(normalized_indexes),
+                    persist=False,
                 )
             else:
                 raise P2PError("invalid_command", "Unsupported command type")
@@ -380,6 +436,7 @@ class P2PRoomManager:
                 state=deepcopy(state),
             )
             self._prune_command_receipts(room)
+            self._persist(room)
             return CommandResult(room, state, False)
 
     def legal_actions(self, room: Room, user_id: str) -> list[str]:
@@ -446,7 +503,7 @@ class P2PRoomManager:
     def _new_code(self) -> str:
         for _ in range(100):
             code = "".join(self._rng.choice(ROOM_ALPHABET) for _ in range(6))
-            if code not in self._rooms:
+            if code not in self._rooms and not (self._store and self._store.exists(code)):
                 return code
         raise P2PError("room_code_exhausted", "Could not allocate a room code")
 
@@ -463,6 +520,8 @@ class P2PRoomManager:
         ]
         for code in expired:
             self._rooms.pop(code, None)
+            if self._store:
+                self._store.delete(code)
 
     @staticmethod
     def _prune_command_receipts(room: Room) -> None:

--- a/backend/app/p2p/persistence.py
+++ b/backend/app/p2p/persistence.py
@@ -1,0 +1,182 @@
+"""Database persistence and optimistic multi-worker coordination for P2P rooms."""
+from __future__ import annotations
+
+from contextlib import contextmanager
+from typing import Iterator
+
+from sqlalchemy import select
+from sqlalchemy.orm import Session, sessionmaker
+
+from ..models import P2PRoomState
+from .manager import CommandReceipt, Player, Room
+
+
+def room_to_snapshot(room: Room) -> dict:
+    return {
+        "code": room.code,
+        "owner_id": room.owner_id,
+        "starting_stack": room.starting_stack,
+        "small_blind": room.small_blind,
+        "big_blind": room.big_blind,
+        "ante": room.ante,
+        "created_at": room.created_at,
+        "updated_at": room.updated_at,
+        "players": {
+            user_id: {
+                "user_id": player.user_id,
+                "display_name": player.display_name,
+                "seat": player.seat,
+                "stack": player.stack,
+                "ready": player.ready,
+                "connected": False,
+                "bet": player.bet,
+                "folded": player.folded,
+                "hand": list(player.hand),
+            }
+            for user_id, player in room.players.items()
+        },
+        "phase": room.phase,
+        "sequence_id": room.sequence_id,
+        "hand_number": room.hand_number,
+        "dealer_seat": room.dealer_seat,
+        "deck": list(room.deck),
+        "pot": room.pot,
+        "current_bet": room.current_bet,
+        "current_actor_id": room.current_actor_id,
+        "acted": sorted(room.acted),
+        "pending_draw": sorted(room.pending_draw),
+        "history": list(room.history),
+        "showdown": room.showdown,
+        "command_receipts": [
+            {
+                "user_id": user_id,
+                "command_id": command_id,
+                "created_at": receipt.created_at,
+                "fingerprint": list(receipt.fingerprint),
+                "state": receipt.state,
+            }
+            for (user_id, command_id), receipt in room.command_receipts.items()
+        ],
+        "closed": room.closed,
+    }
+
+
+def room_from_snapshot(snapshot: dict) -> Room:
+    def freeze(value):
+        if isinstance(value, list):
+            return tuple(freeze(entry) for entry in value)
+        return value
+
+    room = Room(
+        code=str(snapshot["code"]),
+        owner_id=str(snapshot["owner_id"]),
+        starting_stack=int(snapshot["starting_stack"]),
+        small_blind=int(snapshot["small_blind"]),
+        big_blind=int(snapshot["big_blind"]),
+        ante=int(snapshot.get("ante", 0)),
+        created_at=float(snapshot.get("created_at", 0)),
+        updated_at=float(snapshot.get("updated_at", 0)),
+    )
+    room.players = {
+        str(user_id): Player(**player)
+        for user_id, player in (snapshot.get("players") or {}).items()
+    }
+    room.phase = str(snapshot.get("phase", "waiting"))
+    room.sequence_id = int(snapshot.get("sequence_id", 0))
+    room.hand_number = int(snapshot.get("hand_number", 0))
+    room.dealer_seat = int(snapshot.get("dealer_seat", 0))
+    room.deck = list(snapshot.get("deck") or [])
+    room.pot = int(snapshot.get("pot", 0))
+    room.current_bet = int(snapshot.get("current_bet", 0))
+    room.current_actor_id = snapshot.get("current_actor_id")
+    room.acted = set(snapshot.get("acted") or [])
+    room.pending_draw = set(snapshot.get("pending_draw") or [])
+    room.history = list(snapshot.get("history") or [])
+    room.showdown = snapshot.get("showdown")
+    room.command_receipts = {
+        (str(entry["user_id"]), str(entry["command_id"])): CommandReceipt(
+            created_at=float(entry["created_at"]),
+            fingerprint=freeze(entry.get("fingerprint") or []),
+            state=dict(entry.get("state") or {}),
+        )
+        for entry in snapshot.get("command_receipts") or []
+    }
+    room.closed = bool(snapshot.get("closed", False))
+    return room
+
+
+class SQLAlchemyRoomStore:
+    """Persist snapshots and reject stale writes from another worker."""
+
+    def __init__(self, session_factory: sessionmaker):
+        self._session_factory = session_factory
+
+    @contextmanager
+    def _session(self) -> Iterator[Session]:
+        session = self._session_factory()
+        try:
+            yield session
+            session.commit()
+        except Exception:
+            session.rollback()
+            raise
+        finally:
+            session.close()
+
+    def load(self, room_code: str) -> Room | None:
+        with self._session() as session:
+            row = session.get(P2PRoomState, room_code.strip().upper())
+            return room_from_snapshot(row.snapshot) if row and not row.closed else None
+
+    def exists(self, room_code: str) -> bool:
+        return self.load(room_code) is not None
+
+    def save(self, room: Room) -> bool:
+        with self._session() as session:
+            row = session.execute(
+                select(P2PRoomState)
+                .where(P2PRoomState.room_code == room.code)
+                .with_for_update(),
+            ).scalar_one_or_none()
+            if row is None:
+                session.add(P2PRoomState(
+                    room_code=room.code,
+                    owner_id=room.owner_id,
+                    sequence_id=room.sequence_id,
+                    closed=room.closed,
+                    snapshot=room_to_snapshot(room),
+                ))
+                return True
+            if room.sequence_id <= row.sequence_id:
+                return False
+            row.owner_id = room.owner_id
+            row.sequence_id = room.sequence_id
+            row.closed = room.closed
+            row.snapshot = room_to_snapshot(room)
+            return True
+
+    def delete(self, room_code: str) -> None:
+        with self._session() as session:
+            row = session.get(P2PRoomState, room_code.strip().upper())
+            if row:
+                session.delete(row)
+
+    def room_codes_for_user(self, user_id: str) -> list[str]:
+        with self._session() as session:
+            rows = session.scalars(
+                select(P2PRoomState).where(P2PRoomState.closed.is_(False)),
+            )
+            return [
+                row.room_code
+                for row in rows
+                if str(user_id) in (row.snapshot.get("players") or {})
+            ]
+
+    def active_owner_count(self, user_id: str) -> int:
+        with self._session() as session:
+            return len(list(session.scalars(
+                select(P2PRoomState).where(
+                    P2PRoomState.owner_id == str(user_id),
+                    P2PRoomState.closed.is_(False),
+                ),
+            )))

--- a/backend/app/p2p/persistence.py
+++ b/backend/app/p2p/persistence.py
@@ -180,3 +180,17 @@ class SQLAlchemyRoomStore:
                     P2PRoomState.closed.is_(False),
                 ),
             )))
+
+    def prune_expired(self, cutoff_timestamp: float) -> int:
+        """Delete closed or inactive snapshots even when no worker cached them."""
+        with self._session() as session:
+            rows = list(session.scalars(select(P2PRoomState)))
+            expired = [
+                row
+                for row in rows
+                if row.closed
+                or float((row.snapshot or {}).get("updated_at", 0)) < cutoff_timestamp
+            ]
+            for row in expired:
+                session.delete(row)
+            return len(expired)

--- a/backend/tests/test_alembic_clean_install.py
+++ b/backend/tests/test_alembic_clean_install.py
@@ -1,0 +1,125 @@
+import os
+from pathlib import Path
+import sqlite3
+import subprocess
+import sys
+
+
+def test_alembic_clean_install_creates_every_runtime_table(tmp_path: Path):
+    database_path = tmp_path / "clean-install.db"
+    backend_dir = Path(__file__).resolve().parents[1]
+    env = os.environ.copy()
+    env.update(
+        {
+            "BACKEND_ENV": "test",
+            "BACKEND_DB_DRIVER": "sqlite",
+            "BACKEND_DB_NAME": str(database_path),
+        }
+    )
+
+    subprocess.run(
+        [sys.executable, "-m", "alembic", "upgrade", "head"],
+        cwd=backend_dir,
+        env=env,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+    with sqlite3.connect(database_path) as connection:
+        tables = {
+            row[0]
+            for row in connection.execute(
+                "SELECT name FROM sqlite_master WHERE type = 'table'"
+            )
+        }
+        connection.execute(
+            """
+            INSERT INTO badugi_action_logs
+                (hand_id, player_id, phase, round, action, action_type, paid,
+                 is_forced, seq)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            ("clean-hand", "player-1", "BET", 0, "Check", "check", 0, 0, 0),
+        )
+        generated_action_id = connection.execute(
+            "SELECT id FROM badugi_action_logs WHERE hand_id = ?", ("clean-hand",)
+        ).fetchone()
+
+    assert {
+        "users",
+        "badugi_hand_logs",
+        "badugi_hand_actions",
+        "badugi_hand_results",
+        "badugi_action_logs",
+        "tournament_snapshots",
+        "play_feedback_results",
+        "p2p_room_states",
+    } <= tables
+    assert generated_action_id is not None
+    assert generated_action_id[0] > 0
+
+
+def test_reconciliation_preserves_preexisting_user_data(tmp_path: Path):
+    database_path = tmp_path / "existing-install.db"
+    backend_dir = Path(__file__).resolve().parents[1]
+    env = os.environ.copy()
+    env.update(
+        {
+            "BACKEND_ENV": "test",
+            "BACKEND_DB_DRIVER": "sqlite",
+            "BACKEND_DB_NAME": str(database_path),
+        }
+    )
+
+    subprocess.run(
+        [sys.executable, "-m", "alembic", "upgrade", "20260827_01"],
+        cwd=backend_dir,
+        env=env,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    subprocess.run(
+        [
+            sys.executable,
+            "-c",
+            "from app.models import Base; from app.core.db import engine; "
+            "Base.metadata.create_all(engine)",
+        ],
+        cwd=backend_dir,
+        env=env,
+        check=True,
+    )
+    with sqlite3.connect(database_path) as connection:
+        connection.execute(
+            "INSERT INTO users (name, email, hashed_password) VALUES (?, ?, ?)",
+            ("Existing", "existing@example.com", "hash"),
+        )
+        connection.commit()
+
+    subprocess.run(
+        [sys.executable, "-m", "alembic", "upgrade", "head"],
+        cwd=backend_dir,
+        env=env,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+    with sqlite3.connect(database_path) as connection:
+        assert connection.execute(
+            "SELECT name FROM users WHERE email = ?", ("existing@example.com",)
+        ).fetchone() == ("Existing",)
+        connection.execute(
+            """
+            INSERT INTO badugi_action_logs
+                (hand_id, player_id, phase, round, action, action_type, paid,
+                 is_forced, seq)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            ("existing-hand", "player-1", "BET", 0, "Check", "check", 0, 0, 0),
+        )
+        assert connection.execute(
+            "SELECT id FROM badugi_action_logs WHERE hand_id = ?", ("existing-hand",)
+        ).fetchone()[0] > 0

--- a/backend/tests/test_p2p_persistence.py
+++ b/backend/tests/test_p2p_persistence.py
@@ -4,6 +4,7 @@ from sqlalchemy.orm import sessionmaker
 from app.models import Base
 from app.p2p.manager import P2PRoomManager
 from app.p2p.persistence import SQLAlchemyRoomStore
+from app.p2p.manager import ROOM_TTL_SECONDS
 
 
 def build_store(tmp_path):
@@ -106,3 +107,20 @@ def test_sequential_commands_converge_across_two_managers(tmp_path):
     assert recovered.phase == "bet_0"
     assert recovered.hand_number == 1
     assert len(recovered.deck) == 44
+
+
+def test_expired_uncached_room_is_pruned_from_database(tmp_path):
+    store = build_store(tmp_path)
+    first = P2PRoomManager()
+    first.attach_store(store)
+    room = first.create_room(user_id="expired-owner", display_name="Expired")
+
+    stale = store.load(room.code)
+    stale.updated_at -= ROOM_TTL_SECONDS + 1
+    stale.sequence_id += 1
+    assert store.save(stale) is True
+
+    restarted = P2PRoomManager()
+    restarted.attach_store(store)
+    restarted.create_room(user_id="active-owner", display_name="Active")
+    assert store.load(room.code) is None

--- a/backend/tests/test_p2p_persistence.py
+++ b/backend/tests/test_p2p_persistence.py
@@ -1,0 +1,108 @@
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+from app.models import Base
+from app.p2p.manager import P2PRoomManager
+from app.p2p.persistence import SQLAlchemyRoomStore
+
+
+def build_store(tmp_path):
+    engine = create_engine(f"sqlite+pysqlite:///{tmp_path / 'p2p.db'}", future=True)
+    Base.metadata.create_all(engine)
+    return SQLAlchemyRoomStore(sessionmaker(bind=engine, expire_on_commit=False))
+
+
+def test_room_survives_manager_restart_without_leaking_private_cards(tmp_path):
+    store = build_store(tmp_path)
+    first = P2PRoomManager()
+    first.attach_store(store)
+    room = first.create_room(user_id="1", display_name="Host")
+    first.join_room(room.code, user_id="2", display_name="Guest")
+    first.execute_command(
+        room.code,
+        user_id="1",
+        command_id="ready-host-1",
+        hand_id=None,
+        expected_phase="waiting",
+        command_type="ready",
+    )
+    guest_ready = first.execute_command(
+        room.code,
+        user_id="2",
+        command_id="ready-guest-1",
+        hand_id=None,
+        expected_phase="waiting",
+        command_type="ready",
+    )
+
+    restarted = P2PRoomManager()
+    restarted.attach_store(store)
+    recovered = restarted.get_room(room.code)
+    host_state = restarted.public_state(recovered, viewer_id="1")
+    guest_state = restarted.public_state(recovered, viewer_id="2")
+
+    assert recovered.hand_id is not None
+    assert len(host_state["hand"]) == 4
+    assert len(guest_state["hand"]) == 4
+    assert host_state["hand"] != guest_state["hand"]
+    assert all("hand" not in player for player in host_state["players"])
+
+    duplicate = restarted.execute_command(
+        room.code,
+        user_id="2",
+        command_id="ready-guest-1",
+        hand_id=None,
+        expected_phase="waiting",
+        command_type="ready",
+    )
+    assert duplicate.duplicate is True
+    assert duplicate.state == guest_ready.state
+
+
+def test_store_rejects_stale_snapshot_from_another_worker(tmp_path):
+    store = build_store(tmp_path)
+    manager = P2PRoomManager()
+    manager.attach_store(store)
+    room = manager.create_room(user_id="1", display_name="Host")
+    stale = store.load(room.code)
+
+    manager.join_room(room.code, user_id="2", display_name="Guest")
+
+    stale.players["3"] = stale.players["1"]
+    assert store.save(stale) is False
+    latest = store.load(room.code)
+    assert set(latest.players) == {"1", "2"}
+
+
+def test_sequential_commands_converge_across_two_managers(tmp_path):
+    store = build_store(tmp_path)
+    first = P2PRoomManager()
+    second = P2PRoomManager()
+    first.attach_store(store)
+    second.attach_store(store)
+    room = first.create_room(user_id="1", display_name="Host")
+    first.join_room(room.code, user_id="2", display_name="Guest")
+
+    assert set(second.get_room(room.code).players) == {"1", "2"}
+    first.execute_command(
+        room.code,
+        user_id="1",
+        command_id="worker-one-ready",
+        hand_id=None,
+        expected_phase="waiting",
+        command_type="ready",
+    )
+    assert second.get_room(room.code).players["1"].ready is True
+
+    second.execute_command(
+        room.code,
+        user_id="2",
+        command_id="worker-two-ready",
+        hand_id=None,
+        expected_phase="waiting",
+        command_type="ready",
+    )
+    recovered = first.get_room(room.code)
+    assert recovered.phase == "bet_0"
+    assert recovered.hand_number == 1
+    assert len(recovered.deck) == 44

--- a/docs/testing/MGX_QUALITY_PROGRAM_20260828.md
+++ b/docs/testing/MGX_QUALITY_PROGRAM_20260828.md
@@ -1,0 +1,51 @@
+# MGX quality program — 2026-08-28
+
+## Release decision
+
+QA/QM result: **PASS for PR review**. No known P0/P1 product blocker remains in the ten-item scope. Production promotion still requires the normal PR, CI, manual deployment, and post-deploy health checks.
+
+## Ten-item acceptance matrix
+
+| # | Scope | Result | Quality evidence |
+|---|---|---|---|
+| 1 | NLH side pots | PASS | Contribution-tier settlement, folded-player eligibility, multi-all-in and odd-chip tests |
+| 2 | Shared PLO/PLO8/FLH settlement | PASS | High-only and hi/lo contribution-pot resolvers shared by B01-B09; chip-conservation and payout tests |
+| 3 | Core5 real-action tournaments | PASS | Badugi, 2-7 TD, A-5 TD, 2-7 SD and A-5 SD use visible UI actions before a verified champion and grounded review |
+| 4 | World tournament scale | PASS | Production field starts, advances blind level and reaches one champion with complete finish order |
+| 5 | Re-entry rules | PASS | Store/local/national/world explicitly declare no re-entry; no bust/final-table re-entry CTA exists; a new tournament is offered only after completion |
+| 6 | Hand history and replay | PASS | Exact final-state replay plus 35 playable variants preserving hand id, ordered actions, results, pots and frame navigation |
+| 7 | P2P durability | PASS | Room snapshots persist in the database, survive process restart, reject stale sequence writes, prune expired database-only rooms, and preserve viewer privacy; WebSocket and REST fallback flows pass |
+| 8 | 36-game quality gates | PASS | All 36 catalog variants run deterministic ten-hand progression with no skip; one-hand, progression and EV suites are CI gates |
+| 9 | App/controller consolidation | PASS with controlled P2 debt | Badugi uses one public controller path; snapshot selection is extracted and unit-tested; tournament state is synchronized before betting actions. Continued App.jsx decomposition remains maintainability work, not a release blocker |
+| 10 | CI and operations | PASS | CI runs lint, build, Tier1, backend, tournament QA, game progression and EV; production build is chunked without size warnings; dependency audit is clean; migration and deploy static checks pass |
+
+## Final QA evidence
+
+- ESLint: PASS.
+- Production build: PASS, with no chunk-size warning.
+- Dependency audit: 0 vulnerabilities.
+- Tier1: 301 files / 2,066 tests PASS.
+- Tier2: 78 files / 165 tests PASS.
+- Backend: 64 tests PASS, including account deletion and P2P persistence.
+- Game progression: 170 tests PASS; game EV: 25 tests PASS; one-hand gate: 53 tests PASS.
+- Core5 standard soak: cash 10/10 and tournament 10/10 PASS across two seeds per variant.
+- Tournament PR browser gate: 15/15 PASS. Store completed after 33 real Hero hands plus 57 background hands; local completed after 25 real Hero hands plus 140 background hands.
+- Store completion stability: repeated twice after the all-in DRAW fix, both reached a champion.
+- Android Chromium and iPhone WebKit tournament device gate: 2/2 PASS across Core5 layout/action audits.
+- Cross-variant history/replay: 35/35 PASS.
+- P2P: 17 UI tests plus WebSocket and REST-fallback browser flows PASS; backend P2P persistence is included in the full backend suite.
+- Deployment static safety and Alembic upgrade-to-head: PASS.
+
+## Defects found and closed during QA
+
+1. Mobile tournament HUD was clipped above the visual viewport on Android/iPhone landscape. The compact HUD is now passed to the actual HUD child rather than its fragment wrapper.
+2. Tournament Badugi raised using a stale pre-tournament fixed-limit unit. The active blind is now authoritative in controller configuration and action payloads.
+3. A controller could return a successful but non-progressing Hero draw when remaining opponents were all-in. Non-progressing snapshots are rejected and the already-committed table draw is used.
+4. The desktop player status board covered the table by default. It is now collapsed initially.
+5. Chinese Poker's real ten-hand gate exceeded the generic five-second test budget. It retains all ten hands with a variant-specific bounded timeout.
+
+## Controlled follow-up debt
+
+- P2P room state is durable and multi-worker safe through database snapshots and sequence conflicts, but real-time socket fanout remains process-local with polling convergence; cross-node pub/sub is a future scale optimization.
+- B01-B09 have strict shared settlement assertions. The other families have deterministic multi-hand/replay gates, while family-specific payout-oracle expansion remains P2 quality work.
+- App.jsx is still large. Controller snapshot resolution is extracted and the duplicate Badugi public path is removed; further feature-slice extraction should continue in small, regression-gated changes.

--- a/docs/testing/MGX_QUALITY_PROGRAM_20260828.md
+++ b/docs/testing/MGX_QUALITY_PROGRAM_20260828.md
@@ -26,7 +26,7 @@ QA/QM result: **PASS for PR review**. No known P0/P1 product blocker remains in 
 - Dependency audit: 0 vulnerabilities.
 - Tier1: 301 files / 2,066 tests PASS.
 - Tier2: 78 files / 165 tests PASS.
-- Backend: 64 tests PASS, including account deletion and P2P persistence.
+- Backend: 66 tests PASS, including account deletion, P2P persistence, and clean-install migration coverage.
 - Game progression: 170 tests PASS; game EV: 25 tests PASS; one-hand gate: 53 tests PASS.
 - Core5 standard soak: cash 10/10 and tournament 10/10 PASS across two seeds per variant.
 - Tournament PR browser gate: 15/15 PASS. Store completed after 33 real Hero hands plus 57 background hands; local completed after 25 real Hero hands plus 140 background hands.
@@ -43,6 +43,7 @@ QA/QM result: **PASS for PR review**. No known P0/P1 product blocker remains in 
 3. A controller could return a successful but non-progressing Hero draw when remaining opponents were all-in. Non-progressing snapshots are rejected and the already-committed table draw is used.
 4. The desktop player status board covered the table by default. It is now collapsed initially.
 5. Chinese Poker's real ten-hand gate exceeded the generic five-second test budget. It retains all ten hands with a variant-specific bounded timeout.
+6. A clean Alembic database omitted users and hand-history tables, and its SQLite action-log key could not autoincrement. A non-destructive reconciliation migration now creates only missing legacy tables, repairs the SQLite key, preserves existing data, and is covered by clean/existing-install tests.
 
 ## Controlled follow-up debt
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -2243,13 +2243,16 @@
       "license": "MIT"
     },
     "node_modules/baseline-browser-mapping": {
-      "version": "2.8.8",
-      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.8.8.tgz",
-      "integrity": "sha512-be0PUaPsQX/gPWWgFsdD+GFzaoig5PXaUC1xLkQiYdDnANU8sMnHoQd8JhbJQuvTWrWLyeFN9Imb5Qtfvr4RrQ==",
+      "version": "2.11.19",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.11.19.tgz",
+      "integrity": "sha512-Grytf1xOxOEMTGRwx6rLGKkTabd4vMg3VrKdj/7joCmV0qgh4QwMMO6xh34YEXQqirAuUdgQGa5orJQQ+69RBw==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
-        "baseline-browser-mapping": "dist/cli.js"
+        "baseline-browser-mapping": "dist/cli.cjs"
+      },
+      "engines": {
+        "node": ">=6.0.0"
       }
     },
     "node_modules/bidi-js": {
@@ -2300,9 +2303,9 @@
       }
     },
     "node_modules/browserslist": {
-      "version": "4.26.2",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.26.2.tgz",
-      "integrity": "sha512-ECFzp6uFOSB+dcZ5BK/IBaGWssbSYBHvuMeMt3MMFyhI0Z8SqGgEkBLARgpRH3hutIgPVsALcMwbDrJqPxQ65A==",
+      "version": "4.28.8",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.8.tgz",
+      "integrity": "sha512-V2NpofLblG64mfOtSgDhOJESZEGogzDMBv/q+W6oc4LXWP/q75eOXoOaaOu1EOadB9U4Bwx/e0yzbvwKH8zalA==",
       "dev": true,
       "funding": [
         {
@@ -2320,11 +2323,11 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "baseline-browser-mapping": "^2.8.3",
-        "caniuse-lite": "^1.0.30001741",
-        "electron-to-chromium": "^1.5.218",
-        "node-releases": "^2.0.21",
-        "update-browserslist-db": "^1.1.3"
+        "baseline-browser-mapping": "^2.11.12",
+        "caniuse-lite": "^1.0.30001809",
+        "electron-to-chromium": "^1.5.402",
+        "node-releases": "^2.0.53",
+        "update-browserslist-db": "^1.3.0"
       },
       "bin": {
         "browserslist": "cli.js"
@@ -2368,9 +2371,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001745",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001745.tgz",
-      "integrity": "sha512-ywt6i8FzvdgrrrGbr1jZVObnVv6adj+0if2/omv9cmR2oiZs30zL4DIyaptKcbOrBdOIc74QTMoJvSE2QHh5UQ==",
+      "version": "1.0.30001810",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001810.tgz",
+      "integrity": "sha512-TITQPUkaz+aVk5GL6NhOdwk1aEaNTSDPsGFWrTuhKGtjTF70jL/Oht2W4c6rXUe5fu7Ie19VIahAXHIIiWWNeg==",
       "dev": true,
       "funding": [
         {
@@ -2703,9 +2706,9 @@
       "license": "MIT"
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.227",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.227.tgz",
-      "integrity": "sha512-ITxuoPfJu3lsNWUi2lBM2PaBPYgH3uqmxut5vmBxgYvyI4AlJ6P3Cai1O76mOrkJCBzq0IxWg/NtqOrpu/0gKA==",
+      "version": "1.5.415",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.415.tgz",
+      "integrity": "sha512-958V+Kbhtgz+SxXeEVKBjrlKRBIDAYvUJfwhjxMZ5S6ut9jAl7l9ZKBkBrvjyjZE36PabLUo2L8kEeV5O4vgJg==",
       "dev": true,
       "license": "ISC"
     },
@@ -4034,11 +4037,14 @@
       "license": "MIT"
     },
     "node_modules/node-releases": {
-      "version": "2.0.21",
-      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.21.tgz",
-      "integrity": "sha512-5b0pgg78U3hwXkCM8Z9b2FJdPZlr9Psr9V2gQPESdGHqbntyFJKFW4r5TeWGFzafGY3hzs1JC62VEQMbl1JFkw==",
+      "version": "2.0.54",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.54.tgz",
+      "integrity": "sha512-YHs7BmmcsdAI5Ozuf8JZo6PT0mv2GIWC9vMfvUC3dp65M8hn7Ux8CPL+2oBI7juNuj9d0ndhTcznq2ODBps9cQ==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/normalize-path": {
       "version": "3.0.0",
@@ -5340,9 +5346,9 @@
       }
     },
     "node_modules/update-browserslist-db": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.1.3.tgz",
-      "integrity": "sha512-UxhIZQ+QInVdunkDAaiazvvT/+fXL5Osr0JZlJulepYu6Jd7qJtDZjlur0emRlT71EN3ScPoE7gvsuIKKNavKw==",
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.3.1.tgz",
+      "integrity": "sha512-ZZ61DsRsOnakl74HAmp3oSN4aXUmEWXf+i/yv0h7tIBfICc3VdrFErQKUUKPgu3AMsTUMbcongALEN4l6GSUrQ==",
       "dev": true,
       "funding": [
         {

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "test:tournament:pr-e2e": "playwright test --project=tournament-pr-chromium",
     "test:tournament:devices": "playwright test --project=tournament-android-chromium --project=tournament-iphone-webkit",
     "test:p2p": "vitest run src/ui/screens/__tests__/FriendMatchSetupScreen.test.jsx --project=tier2 && playwright test tests/e2e/p2p-friend-match-production-ws.spec.ts tests/e2e/p2p-friend-match-rest-fallback.spec.ts --project=badugi-flow",
+    "test:deploy:static": "bash scripts/deploy/test-mgx-prod-01-static.sh",
     "test:ai-evaluation": "vitest run --project=tier3 src/ai/evaluation --silent=passed-only",
     "test:all:serial": "npm run test:tier1 -- --pool=forks --maxWorkers=1 --no-file-parallelism --silent=passed-only && npm run test:tier2 -- --pool=forks --maxWorkers=1 --no-file-parallelism --silent=passed-only && npm run test:tier3",
     "test:artifacts": "vitest run --config vitest.artifacts.config.js",

--- a/playwright.config.js
+++ b/playwright.config.js
@@ -29,7 +29,7 @@ export default defineConfig({
     {
       name: 'tournament-pr-chromium',
       testDir: './tests/e2e',
-      testMatch: /tournament-(reconnect-ui|stage-blind-transition)\.spec\.ts/,
+      testMatch: /(?:tournament-(?:reconnect-ui|stage-blind-transition)|core5-real-action-champion)\.spec\.ts/,
       use: {
         ...devices['Desktop Chrome'],
       },

--- a/scripts/deploy/mgx-prod-01.sh
+++ b/scripts/deploy/mgx-prod-01.sh
@@ -154,6 +154,8 @@ else
   echo "[mgx-deploy] missing backend requirements.txt or pyproject.toml"
   exit 1
 fi
+echo "[mgx-deploy] applying backend database migrations"
+alembic upgrade head
 deactivate
 cd "$APP_DIR"
 

--- a/scripts/deploy/test-mgx-prod-01-static.sh
+++ b/scripts/deploy/test-mgx-prod-01-static.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+script="scripts/deploy/mgx-prod-01.sh"
+bash -n "$script"
+
+migration_line="$(grep -n 'alembic upgrade head' "$script" | cut -d: -f1)"
+restart_line="$(grep -n 'systemctl restart mgx-backend.service' "$script" | cut -d: -f1)"
+test -n "$migration_line"
+test -n "$restart_line"
+test "$migration_line" -lt "$restart_line"
+grep -q 'verify_live_frontend' "$script"
+grep -q 'verify_live_p2p_rest_route' "$script"
+
+echo "deploy static safety: PASS"

--- a/src/config/tournamentStages.js
+++ b/src/config/tournamentStages.js
@@ -39,6 +39,7 @@ export const TOURNAMENT_STAGES = [
     gameVariant: "badugi",
     gameRotation: ["badugi"],
     rotationPolicy: "fixed",
+    reentryPolicy: { allowed: false, maxEntries: 1, closesAtLevel: 0 },
   },
   {
     id: "local",
@@ -71,6 +72,7 @@ export const TOURNAMENT_STAGES = [
     gameVariant: "badugi",
     gameRotation: ["badugi"],
     rotationPolicy: "fixed",
+    reentryPolicy: { allowed: false, maxEntries: 1, closesAtLevel: 0 },
   },
   {
     id: "national",
@@ -105,6 +107,7 @@ export const TOURNAMENT_STAGES = [
     gameVariant: "badugi",
     gameRotation: ["badugi"],
     rotationPolicy: "fixed",
+    reentryPolicy: { allowed: false, maxEntries: 1, closesAtLevel: 0 },
     proBlindSheetId: "national-premier-pro",
   },
   {
@@ -142,6 +145,7 @@ export const TOURNAMENT_STAGES = [
     gameVariant: "badugi",
     gameRotation: ["badugi"],
     rotationPolicy: "fixed",
+    reentryPolicy: { allowed: false, maxEntries: 1, closesAtLevel: 0 },
     proBlindSheetId: "world-championship-pro",
   },
 ];

--- a/src/games/badugi/controller/BadugiGameController.js
+++ b/src/games/badugi/controller/BadugiGameController.js
@@ -167,6 +167,52 @@ export class BadugiGameController extends GameController {
     this._lastState = null;
   }
 
+  // Compatibility surface for the UI while all callers migrate to the
+  // GameController state/action API. Keeping it here makes this wrapper the
+  // single public Badugi controller path instead of importing the legacy
+  // implementation directly from App.
+  updateConfig(partial = {}) {
+    this.config = { ...this.config, ...partial };
+    this.legacy.updateConfig(partial);
+  }
+
+  syncExternalState(partial = {}) {
+    this.legacy.syncExternalState(partial);
+    this._lastState = this._buildControllerState({
+      handIndex: this._lastState?.handIndex ?? 0,
+      context: this._lastState?.context ?? null,
+    });
+  }
+
+  setHandContext(context = {}) {
+    this.legacy.setHandContext(context);
+  }
+
+  getSnapshot() {
+    return this.legacy.getSnapshot();
+  }
+
+  startNewHand(options = {}) {
+    const result = this.legacy.startNewHand(options);
+    this._lastState = this._buildControllerState({
+      handIndex: (this._lastState?.handIndex ?? 0) + 1,
+      context: result,
+    });
+    return result;
+  }
+
+  applyPlayerAction(options = {}) {
+    return this.legacy.applyPlayerAction(options);
+  }
+
+  advanceStreet(options = {}) {
+    return this.legacy.advanceStreet(options);
+  }
+
+  resolveShowdown(options = {}) {
+    return this.legacy.resolveShowdown(options);
+  }
+
   createInitialState(tableConfig = {}) {
     this._applyTableConfig(tableConfig);
     return this._buildControllerState({

--- a/src/games/badugi/controller/BadugiGameController.js
+++ b/src/games/badugi/controller/BadugiGameController.js
@@ -639,6 +639,18 @@ export class BadugiGameController extends GameController {
       ...this.config,
       ...partial,
     };
+    if (partial.betSize == null) {
+      const blindIndex = Math.max(
+        0,
+        Number(partial.blindState?.blindLevelIndex) || 0,
+      );
+      const activeBigBlind =
+        Number(partial.structure?.bb) ||
+        Number(partial.blindStructure?.[blindIndex]?.bb) ||
+        Number(partial.blindStructure?.[0]?.bb) ||
+        null;
+      if (activeBigBlind != null) merged.betSize = activeBigBlind;
+    }
     if (!merged.seatConfig || merged.seatConfig.length === 0) {
       merged.seatConfig = DEFAULT_SEAT_CONFIG;
     }

--- a/src/games/badugi/controller/__tests__/BadugiGameController.test.js
+++ b/src/games/badugi/controller/__tests__/BadugiGameController.test.js
@@ -53,6 +53,34 @@ function ensureDrawPhase(controller, state, seatIndex = 0) {
 }
 
 describe("BadugiGameController – new hand", () => {
+  it("provides the legacy-compatible UI surface from the canonical controller path", () => {
+    const controller = new BadugiGameController({
+      numSeats: 2,
+      seatConfig: ["HUMAN", "CPU"],
+      startingStack: 200,
+      blindStructure: [{ sb: 5, bb: 10, ante: 0 }],
+    });
+
+    controller.updateConfig({ lastStructureIndex: 0 });
+    const started = controller.startNewHand({
+      currentPlayers: [],
+      numSeats: 2,
+      seatConfig: ["HUMAN", "CPU"],
+      startingStack: 200,
+      heroProfile: { name: "Hero" },
+      nextDealerIdx: 0,
+      blindStructure: [{ sb: 5, bb: 10, ante: 0 }],
+      drawCardsForSeat: () => ["AS", "2H", "3D", "4C"],
+    });
+
+    expect(started.players).toHaveLength(2);
+    expect(controller.getSnapshot().players).toHaveLength(2);
+    expect(typeof controller.syncExternalState).toBe("function");
+    expect(typeof controller.applyPlayerAction).toBe("function");
+    expect(typeof controller.advanceStreet).toBe("function");
+    expect(typeof controller.resolveShowdown).toBe("function");
+  });
+
   it("creates a new hand with players, stacks, and blinds", () => {
     const controller = createController();
     const initial = controller.createInitialState({

--- a/src/games/badugi/controller/__tests__/BadugiGameController.test.js
+++ b/src/games/badugi/controller/__tests__/BadugiGameController.test.js
@@ -104,6 +104,34 @@ describe("BadugiGameController – new hand", () => {
     expect(typeof (snap.turn ?? snap.nextTurn)).toBe("number");
     expect(typeof (snap.dealerSeat ?? snap.dealerIdx)).toBe("number");
   });
+
+  it("uses the active tournament blind as the fixed-limit raise unit", () => {
+    const controller = createController({
+      blindStructure: [{ sb: 1, bb: 2, ante: 0 }],
+    });
+    const initial = controller.createInitialState({
+      seatConfig: ["HERO", "CPU", "CPU", "CPU"],
+      structure: { sb: 1, bb: 2, ante: 0 },
+    });
+    const state = controller.createNewHandState(initial, {
+      blindStructure: [{ sb: 25, bb: 50, ante: 0 }],
+      blindState: { blindLevelIndex: 0, handsInLevel: 0 },
+      structure: { sb: 25, bb: 50, ante: 0 },
+    });
+    const snapshot = controller.getUiSnapshot(state);
+    const actingSeat = snapshot.turn ?? snapshot.nextTurn;
+    const actorBet = snapshot.players[actingSeat]?.betThisRound ?? 0;
+    const toCall = Math.max(0, Number(snapshot.currentBet) - actorBet);
+    const { events, state: raisedState } = controller.applyAction(state, {
+      seatIndex: actingSeat,
+      payload: { type: "raise", amount: toCall + 50 },
+    });
+
+    expect(events.some((event) => event.type === "invalidAction")).toBe(false);
+    expect(controller.getUiSnapshot(raisedState).players[actingSeat].betThisRound).toBe(
+      actorBet + toCall + 50,
+    );
+  });
 });
 
 describe("BadugiGameController – betting", () => {

--- a/src/games/core/__tests__/sidePotResolver.test.js
+++ b/src/games/core/__tests__/sidePotResolver.test.js
@@ -1,100 +1,57 @@
 import { describe, expect, it } from "vitest";
 import {
-  applyPayoutsToPlayers,
   buildContributionPots,
-  resolveEvaluationPot,
-  splitAmountBySeatOrder,
-  summarizePayouts,
+  resolveHiLoContributionPots,
 } from "../sidePotResolver.js";
 
-function compareLowestScore(a, b) {
-  return a.score - b.score;
-}
+const player = (seatIndex, totalInvested, extra = {}) => ({
+  seatIndex,
+  name: `P${seatIndex}`,
+  totalInvested,
+  stack: 0,
+  ...extra,
+});
 
-describe("sidePotResolver", () => {
-  it("builds contribution pots from all-in investments while excluding folded winners", () => {
+describe("shared side-pot settlement", () => {
+  it("includes folded chips but excludes folded seats from every award", () => {
     const pots = buildContributionPots([
-      { totalInvested: 50, folded: false },
-      { totalInvested: 100, folded: false },
-      { totalInvested: 200, folded: false },
-      { totalInvested: 200, folded: true },
+      player(0, 25),
+      player(1, 50, { folded: true }),
+      player(2, 100),
     ]);
 
     expect(pots).toEqual([
-      {
-        potIndex: 0,
-        amount: 200,
-        potAmount: 200,
-        contributorSeatIndexes: [0, 1, 2, 3],
-        eligibleSeatIndexes: [0, 1, 2],
-      },
-      {
-        potIndex: 1,
-        amount: 150,
-        potAmount: 150,
-        contributorSeatIndexes: [1, 2, 3],
-        eligibleSeatIndexes: [1, 2],
-      },
-      {
-        potIndex: 2,
-        amount: 200,
-        potAmount: 200,
-        contributorSeatIndexes: [2, 3],
-        eligibleSeatIndexes: [2],
-      },
+      expect.objectContaining({ amount: 75, eligibleSeatIndexes: [0, 2] }),
+      expect.objectContaining({ amount: 50, eligibleSeatIndexes: [2] }),
+      expect.objectContaining({ amount: 50, eligibleSeatIndexes: [2] }),
     ]);
   });
 
-  it("splits odd chips by stable seat order", () => {
-    expect(splitAmountBySeatOrder(101, [{ seatIndex: 2 }, { seatIndex: 0 }])).toEqual([
-      { seatIndex: 0, payout: 51 },
-      { seatIndex: 2, payout: 50 },
-    ]);
-  });
-
-  it("resolves a pot only among eligible contenders", () => {
-    const players = [
-      { seatIndex: 0, name: "Main" },
-      { seatIndex: 1, name: "Side" },
-      { seatIndex: 2, name: "Deep" },
-    ];
-    const evaluations = players.map((player, idx) => ({
-      player,
-      evaluation: { score: [1, 2, 0][idx] },
+  it("awards the odd hi/lo chip to high and preserves the complete pot", () => {
+    const players = [player(0, 33), player(1, 33), player(2, 33)];
+    const highEvaluations = players.map((entry, index) => ({
+      player: entry,
+      evaluation: { rank: index },
     }));
-
-    const payouts = resolveEvaluationPot({
-      amount: 100,
-      eligibleSeatIndexes: [1, 2],
-      evaluations,
-      compareEvaluations: compareLowestScore,
+    const lowEvaluations = [
+      { player: players[1], evaluation: { rank: 0 } },
+      { player: players[2], evaluation: { rank: 1 } },
+    ];
+    const { payouts, potDetails } = resolveHiLoContributionPots({
+      players,
+      highEvaluations,
+      lowEvaluations,
+      compareHighEvaluations: (left, right) => left.rank - right.rank,
+      compareLowEvaluations: (left, right) => left.rank - right.rank,
+      totalPot: 99,
     });
 
-    expect(payouts).toHaveLength(1);
-    expect(payouts[0]).toMatchObject({
-      player: players[2],
-      payout: 100,
-      evaluation: { score: 0 },
-    });
-  });
-
-  it("applies and summarizes payouts by seat", () => {
-    const players = [
-      { seatIndex: 0, name: "Hero", stack: 0 },
-      { seatIndex: 1, name: "CPU", stack: 0 },
-    ];
-    const payouts = [
-      { player: players[0], payout: 75, evaluation: { score: 1 } },
-      { player: players[0], payout: 25, evaluation: { score: 2 } },
-      { player: players[1], payout: 50, evaluation: { score: 3 } },
-    ];
-
-    applyPayoutsToPlayers(players, payouts);
-
-    expect(players.map((player) => player.stack)).toEqual([100, 50]);
-    expect(summarizePayouts(payouts)).toEqual([
-      { seatIndex: 0, name: "Hero", payout: 100, evaluation: { score: 1 } },
-      { seatIndex: 1, name: "CPU", payout: 50, evaluation: { score: 3 } },
+    expect(potDetails[0].highWinners).toEqual([
+      expect.objectContaining({ seatIndex: 0, payout: 50 }),
     ]);
+    expect(potDetails[0].lowWinners).toEqual([
+      expect.objectContaining({ seatIndex: 1, payout: 49 }),
+    ]);
+    expect(payouts.reduce((sum, payout) => sum + payout.payout, 0)).toBe(99);
   });
 });

--- a/src/games/core/sidePotResolver.js
+++ b/src/games/core/sidePotResolver.js
@@ -96,3 +96,91 @@ export function summarizePayouts(payouts = []) {
   });
   return [...bySeat.values()].sort((a, b) => a.seatIndex - b.seatIndex);
 }
+
+function contributionPotsOrFallback(players, totalPot, evaluations) {
+  const contributionPots = buildContributionPots(players);
+  if (contributionPots.length) return contributionPots;
+  return [{
+    potIndex: 0,
+    amount: totalPot,
+    potAmount: totalPot,
+    eligibleSeatIndexes: evaluations.map((entry) => entry.player.seatIndex),
+  }];
+}
+
+function payoutSummary(entry) {
+  return {
+    seatIndex: entry.player.seatIndex,
+    name: entry.player.name,
+    payout: entry.payout,
+    evaluation: entry.evaluation,
+  };
+}
+
+export function resolveHighContributionPots({
+  players = [],
+  evaluations = [],
+  compareEvaluations,
+  totalPot = 0,
+} = {}) {
+  const payouts = [];
+  const potDetails = contributionPotsOrFallback(players, totalPot, evaluations)
+    .map((pot, potIndex) => {
+      const potPayouts = resolveEvaluationPot({
+        amount: pot.amount,
+        eligibleSeatIndexes: pot.eligibleSeatIndexes,
+        evaluations,
+        compareEvaluations,
+      });
+      payouts.push(...potPayouts);
+      return {
+        potIndex: pot.potIndex ?? potIndex,
+        amount: pot.amount,
+        potAmount: pot.amount,
+        eligibleSeatIndexes: [...(pot.eligibleSeatIndexes ?? [])],
+        winnerSeatIndexes: potPayouts.map((winner) => winner.player.seatIndex),
+        winners: potPayouts.map(payoutSummary),
+      };
+    });
+  return { payouts, potDetails };
+}
+
+export function resolveHiLoContributionPots({
+  players = [],
+  highEvaluations = [],
+  lowEvaluations = [],
+  compareHighEvaluations,
+  compareLowEvaluations,
+  totalPot = 0,
+} = {}) {
+  const payouts = [];
+  const potDetails = contributionPotsOrFallback(players, totalPot, highEvaluations)
+    .map((pot, potIndex) => {
+      const eligible = new Set(pot.eligibleSeatIndexes ?? []);
+      const eligibleLow = lowEvaluations.filter((entry) => eligible.has(entry.player.seatIndex));
+      const highAmount = eligibleLow.length ? Math.ceil(pot.amount / 2) : pot.amount;
+      const lowAmount = eligibleLow.length ? pot.amount - highAmount : 0;
+      const highPayouts = resolveEvaluationPot({
+        amount: highAmount,
+        eligibleSeatIndexes: pot.eligibleSeatIndexes,
+        evaluations: highEvaluations,
+        compareEvaluations: compareHighEvaluations,
+      });
+      const lowPayouts = resolveEvaluationPot({
+        amount: lowAmount,
+        eligibleSeatIndexes: pot.eligibleSeatIndexes,
+        evaluations: lowEvaluations,
+        compareEvaluations: compareLowEvaluations,
+      });
+      payouts.push(...highPayouts, ...lowPayouts);
+      return {
+        potIndex: pot.potIndex ?? potIndex,
+        amount: pot.amount,
+        potAmount: pot.amount,
+        eligibleSeatIndexes: [...(pot.eligibleSeatIndexes ?? [])],
+        highWinners: highPayouts.map(payoutSummary),
+        lowWinners: lowPayouts.map(payoutSummary),
+      };
+    });
+  return { payouts, potDetails };
+}

--- a/src/games/nlh/NLHGameController.js
+++ b/src/games/nlh/NLHGameController.js
@@ -6,8 +6,7 @@ import { DeckManager } from "../badugi/utils/deck.js";
 import { applyChips } from "../core/applyChips.js";
 import {
   applyPayoutsToPlayers,
-  buildContributionPots,
-  resolveEvaluationPot,
+  resolveHighContributionPots,
   summarizePayouts,
 } from "../core/sidePotResolver.js";
 import {
@@ -619,42 +618,11 @@ export class NLHGameController {
       this.state.lastHandResult = summary;
       return summary;
     }
-    const winners = evaluations.filter(
-      (entry) => compareNlhHands(entry.evaluation, best.evaluation) === 0,
-    );
-    const contributionPots = buildContributionPots(this.state.players);
-    const potsToResolve = contributionPots.length
-      ? contributionPots
-      : [
-          {
-            potIndex: 0,
-            amount: resolvedPot,
-            potAmount: resolvedPot,
-            eligibleSeatIndexes: winners.map((entry) => entry.player.seatIndex),
-          },
-        ];
-    const allPayouts = [];
-    const potDetails = potsToResolve.map((pot, potIndex) => {
-      const payouts = resolveEvaluationPot({
-        amount: pot.amount,
-        eligibleSeatIndexes: pot.eligibleSeatIndexes,
-        evaluations,
-        compareEvaluations: compareNlhHands,
-      });
-      allPayouts.push(...payouts);
-      return {
-        potIndex: pot.potIndex ?? potIndex,
-        amount: pot.amount,
-        potAmount: pot.amount,
-        eligibleSeatIndexes: [...(pot.eligibleSeatIndexes ?? [])],
-        winnerSeatIndexes: payouts.map((winner) => winner.player.seatIndex),
-        winners: payouts.map((winner) => ({
-          seatIndex: winner.player.seatIndex,
-          name: winner.player.name,
-          payout: winner.payout,
-          evaluation: winner.evaluation,
-        })),
-      };
+    const { payouts: allPayouts, potDetails } = resolveHighContributionPots({
+      players: this.state.players,
+      evaluations,
+      compareEvaluations: compareNlhHands,
+      totalPot: resolvedPot,
     });
     applyPayoutsToPlayers(this.state.players, allPayouts);
     const winnerSummaries = summarizePayouts(allPayouts);

--- a/src/games/plo/PLO8GameController.js
+++ b/src/games/plo/PLO8GameController.js
@@ -2,10 +2,8 @@ import { combinations } from "../evaluators/core.js";
 import { evaluateLowHand } from "../evaluators/low.js";
 import {
   applyPayoutsToPlayers,
-  buildContributionPots,
-  resolveEvaluationPot,
+  resolveHiLoContributionPots,
   summarizePayouts,
-  splitAmountBySeatOrder,
 } from "../core/sidePotResolver.js";
 import PLOGameController from "./PLOGameController.js";
 import PLO8GameDefinition from "./PLO8GameDefinition.js";
@@ -70,50 +68,13 @@ export class PLO8GameController extends PLOGameController {
       }))
       .filter((entry) => entry.evaluation?.qualifies);
     const resolvedPot = totalPot ?? this.calculatePot();
-    const contributionPots = buildContributionPots(this.state.players);
-    const potsToResolve = contributionPots.length
-      ? contributionPots
-      : [{ potIndex: 0, amount: resolvedPot, potAmount: resolvedPot, eligibleSeatIndexes: contenders.map((p) => p.seatIndex) }];
-    const allPayouts = [];
-    const potDetails = potsToResolve.map((pot, potIndex) => {
-      const eligibleLow = lowEvaluations.filter((entry) =>
-        (pot.eligibleSeatIndexes ?? []).includes(entry.player.seatIndex),
-      );
-      const highAmount = eligibleLow.length ? Math.ceil(pot.amount / 2) : pot.amount;
-      const lowAmount = eligibleLow.length ? pot.amount - highAmount : 0;
-      const highPayouts = resolveEvaluationPot({
-        amount: highAmount,
-        eligibleSeatIndexes: pot.eligibleSeatIndexes,
-        evaluations: highEvaluations,
-        compareEvaluations: comparePloHands,
-      });
-      const lowBest = eligibleLow.reduce(
-        (best, entry) => (!best || compareLowHands(entry.evaluation, best.evaluation) < 0 ? entry : best),
-        null,
-      );
-      const lowWinners = lowBest
-        ? eligibleLow.filter((entry) => compareLowHands(entry.evaluation, lowBest.evaluation) === 0)
-        : [];
-      const lowPayouts = splitAmountBySeatOrder(lowAmount, lowWinners);
-      allPayouts.push(...highPayouts, ...lowPayouts);
-      return {
-        potIndex: pot.potIndex ?? potIndex,
-        amount: pot.amount,
-        potAmount: pot.amount,
-        eligibleSeatIndexes: [...(pot.eligibleSeatIndexes ?? [])],
-        highWinners: highPayouts.map((winner) => ({
-          seatIndex: winner.player.seatIndex,
-          name: winner.player.name,
-          payout: winner.payout,
-          evaluation: winner.evaluation,
-        })),
-        lowWinners: lowPayouts.map((winner) => ({
-          seatIndex: winner.player.seatIndex,
-          name: winner.player.name,
-          payout: winner.payout,
-          evaluation: winner.evaluation,
-        })),
-      };
+    const { payouts: allPayouts, potDetails } = resolveHiLoContributionPots({
+      players: this.state.players,
+      highEvaluations,
+      lowEvaluations,
+      compareHighEvaluations: comparePloHands,
+      compareLowEvaluations: compareLowHands,
+      totalPot: resolvedPot,
     });
     applyPayoutsToPlayers(this.state.players, allPayouts);
     const summary = {

--- a/src/games/plo/PLOGameController.js
+++ b/src/games/plo/PLOGameController.js
@@ -4,8 +4,7 @@ import { evaluatePloHand, comparePloHands } from "./utils/ploEvaluator.js";
 import { estimateBoardHandStrength } from "../core/cpuTeacherPolicy.js";
 import {
   applyPayoutsToPlayers,
-  buildContributionPots,
-  resolveEvaluationPot,
+  resolveHighContributionPots,
   summarizePayouts,
 } from "../core/sidePotResolver.js";
 
@@ -116,42 +115,11 @@ export class PLOGameController extends NLHGameController {
       this.state.lastHandResult = summary;
       return summary;
     }
-    const winners = evaluations.filter(
-      (entry) => comparePloHands(entry.evaluation, best.evaluation) === 0,
-    );
-    const contributionPots = buildContributionPots(this.state.players);
-    const potsToResolve = contributionPots.length
-      ? contributionPots
-      : [
-          {
-            potIndex: 0,
-            amount: resolvedPot,
-            potAmount: resolvedPot,
-            eligibleSeatIndexes: winners.map((entry) => entry.player.seatIndex),
-          },
-        ];
-    const allPayouts = [];
-    const potDetails = potsToResolve.map((pot, potIndex) => {
-      const payouts = resolveEvaluationPot({
-        amount: pot.amount,
-        eligibleSeatIndexes: pot.eligibleSeatIndexes,
-        evaluations,
-        compareEvaluations: comparePloHands,
-      });
-      allPayouts.push(...payouts);
-      return {
-        potIndex: pot.potIndex ?? potIndex,
-        amount: pot.amount,
-        potAmount: pot.amount,
-        eligibleSeatIndexes: [...(pot.eligibleSeatIndexes ?? [])],
-        winnerSeatIndexes: payouts.map((winner) => winner.player.seatIndex),
-        winners: payouts.map((winner) => ({
-          seatIndex: winner.player.seatIndex,
-          name: winner.player.name,
-          payout: winner.payout,
-          evaluation: winner.evaluation,
-        })),
-      };
+    const { payouts: allPayouts, potDetails } = resolveHighContributionPots({
+      players: this.state.players,
+      evaluations,
+      compareEvaluations: comparePloHands,
+      totalPot: resolvedPot,
     });
     applyPayoutsToPlayers(this.state.players, allPayouts);
     const winnerSummaries = summarizePayouts(allPayouts);

--- a/src/games/testing/ev/strictVariantSettlementGate.js
+++ b/src/games/testing/ev/strictVariantSettlementGate.js
@@ -1,15 +1,19 @@
 import { getVariantById } from "../../config/variantCatalog.js";
 import { compareNlhHands, evaluateNlhHand } from "../../nlh/utils/nlhEvaluator.js";
+import { comparePloHands, evaluatePloHand } from "../../plo/utils/ploEvaluator.js";
+import { evaluateOmahaEightLow } from "../../plo/PLO8GameController.js";
 import { extractPayouts, validateHandEvIntegrity } from "./evIntegrityChecker.js";
+
+const STRICT_BOARD_VARIANTS = new Set(["B01", "B02", "B05", "B06", "B09"]);
 
 const FAMILY_ALLOWLISTS = Object.freeze([
   {
-    ids: ["B02", "B03", "B04"],
-    reason: "Board pilot expansion awaits variant-specific fixed-limit and three-hole settlement fixtures.",
+    ids: ["B03", "B04"],
+    reason: "Three-hole board settlement awaits variant-specific evaluator and side-pot fixtures.",
   },
   {
-    ids: ["B05", "B06", "B07", "B08", "B09"],
-    reason: "Omaha settlement awaits strict must-use-two, side-pot, hi/lo, quartering, and odd-chip fixtures.",
+    ids: ["B07", "B08"],
+    reason: "Five-card Omaha settlement awaits strict must-use-two and side-pot fixtures.",
   },
   {
     ids: ["D01", "D02", "D03", "D04", "D05", "D06", "D07", "S01", "S02", "S03", "S04", "S05", "S06", "S07"],
@@ -40,7 +44,7 @@ export function getStrictSettlementPolicy(variantId) {
   if (!variant) {
     return { variantId, status: "UNKNOWN", reason: "Variant is absent from the canonical catalog." };
   }
-  if (variant.id === "B01") {
+  if (STRICT_BOARD_VARIANTS.has(variant.id)) {
     return { variantId: variant.id, status: "ENFORCED", reason: null };
   }
   const reason = STRICT_SETTLEMENT_ALLOWLIST[variant.id];
@@ -55,21 +59,56 @@ function seatIndexOf(player, fallback) {
   return player?.seatIndex ?? fallback;
 }
 
-function verifyNlhPotWinners(afterState, result) {
-  const errors = [];
+function buildBoardEvaluations(variantId, afterState, result) {
   const board = afterState?.boardCards ?? result?.board ?? [];
-  const players = afterState?.players ?? [];
-  const evaluations = players
-    .map((player, index) => ({
-      player,
-      seatIndex: seatIndexOf(player, index),
-      evaluation:
-        !player?.folded && !player?.seatOut && player?.holeCards?.length === 2 && board.length === 5
-          ? evaluateNlhHand({ cards: [...player.holeCards, ...board] })
+  return (afterState?.players ?? [])
+    .map((player, index) => {
+      const seatIndex = seatIndexOf(player, index);
+      if (player?.folded || player?.seatOut) return null;
+      if (variantId === "B01" || variantId === "B02") {
+        if (player?.holeCards?.length !== 2 || board.length !== 5) return null;
+        return {
+          player,
+          seatIndex,
+          high: evaluateNlhHand({ cards: [...player.holeCards, ...board] }),
+          low: null,
+        };
+      }
+      if (!Array.isArray(player?.holeCards) || player.holeCards.length < 4 || board.length !== 5) {
+        return null;
+      }
+      return {
+        player,
+        seatIndex,
+        high: evaluatePloHand({ holeCards: player.holeCards, boardCards: board }),
+        low: variantId === "B06" || variantId === "B09"
+          ? evaluateOmahaEightLow({ holeCards: player.holeCards, boardCards: board })
           : null,
-    }))
-    .filter((entry) => entry.evaluation);
+      };
+    })
+    .filter(Boolean);
+}
+
+function expectedWinnerSeats(entries, evaluationKey, compareEvaluations) {
+  const candidates = entries.filter((entry) => entry[evaluationKey]);
+  if (!candidates.length) return [];
+  const best = candidates.reduce((current, entry) =>
+    !current || compareEvaluations(entry[evaluationKey], current[evaluationKey]) < 0
+      ? entry
+      : current,
+  null);
+  return candidates
+    .filter((entry) => compareEvaluations(entry[evaluationKey], best[evaluationKey]) === 0)
+    .map((entry) => entry.seatIndex)
+    .sort((left, right) => left - right);
+}
+
+function verifyBoardPotWinners(variantId, afterState, result) {
+  const errors = [];
+  const evaluations = buildBoardEvaluations(variantId, afterState, result);
   const payouts = extractPayouts(result);
+  const compareHigh = variantId === "B01" || variantId === "B02" ? compareNlhHands : comparePloHands;
+  const split = variantId === "B06" || variantId === "B09";
 
   for (const [potIndex, pot] of (result?.potDetails ?? []).entries()) {
     const eligible = new Set(pot.eligibleSeatIndexes ?? evaluations.map((entry) => entry.seatIndex));
@@ -78,19 +117,47 @@ function verifyNlhPotWinners(afterState, result) {
       errors.push({ code: "strict_nlh_pot_has_no_evaluable_player", potIndex });
       continue;
     }
-    const best = candidates.reduce((current, entry) =>
-      !current || compareNlhHands(entry.evaluation, current.evaluation) < 0 ? entry : current,
-    null);
-    const expected = candidates
-      .filter((entry) => compareNlhHands(entry.evaluation, best.evaluation) === 0)
-      .map((entry) => entry.seatIndex)
-      .sort((left, right) => left - right);
-    const actual = payouts
-      .filter((payout) => (payout.potIndex ?? 0) === potIndex && Number(payout.amount) > 0)
+    const expectedHigh = expectedWinnerSeats(candidates, "high", compareHigh);
+    const actualHigh = payouts
+      .filter((payout) =>
+        (payout.potIndex ?? 0) === potIndex &&
+        Number(payout.amount) > 0 &&
+        (!split || payout.component === "high"),
+      )
       .map((payout) => payout.seatIndex)
       .sort((left, right) => left - right);
-    if (JSON.stringify(actual) !== JSON.stringify(expected)) {
-      errors.push({ code: "strict_nlh_evaluator_winner_mismatch", potIndex, expected, actual });
+    if (JSON.stringify(actualHigh) !== JSON.stringify(expectedHigh)) {
+      errors.push({
+        code: "strict_board_high_winner_mismatch",
+        variantId,
+        potIndex,
+        expected: expectedHigh,
+        actual: actualHigh,
+      });
+    }
+    if (split) {
+      const expectedLow = expectedWinnerSeats(
+        candidates,
+        "low",
+        (left, right) => left.rankPrimary - right.rankPrimary,
+      );
+      const actualLow = payouts
+        .filter((payout) =>
+          (payout.potIndex ?? 0) === potIndex &&
+          Number(payout.amount) > 0 &&
+          payout.component === "low",
+        )
+        .map((payout) => payout.seatIndex)
+        .sort((left, right) => left - right);
+      if (JSON.stringify(actualLow) !== JSON.stringify(expectedLow)) {
+        errors.push({
+          code: "strict_board_low_winner_mismatch",
+          variantId,
+          potIndex,
+          expected: expectedLow,
+          actual: actualLow,
+        });
+      }
     }
   }
   return errors;
@@ -134,8 +201,7 @@ export function validateStrictVariantSettlement({
       });
     }
   }
-  strictErrors.push(...verifyNlhPotWinners(afterState, result));
+  strictErrors.push(...verifyBoardPotWinners(variantId, afterState, result));
   const errors = [...check.errors, ...strictErrors];
   return { ok: errors.length === 0, policy, errors, check };
 }
-

--- a/src/games/testing/ev/strictVariantSettlementGate.js
+++ b/src/games/testing/ev/strictVariantSettlementGate.js
@@ -4,17 +4,11 @@ import { comparePloHands, evaluatePloHand } from "../../plo/utils/ploEvaluator.j
 import { evaluateOmahaEightLow } from "../../plo/PLO8GameController.js";
 import { extractPayouts, validateHandEvIntegrity } from "./evIntegrityChecker.js";
 
-const STRICT_BOARD_VARIANTS = new Set(["B01", "B02", "B05", "B06", "B09"]);
+const STRICT_BOARD_VARIANTS = new Set([
+  "B01", "B02", "B03", "B04", "B05", "B06", "B07", "B08", "B09",
+]);
 
 const FAMILY_ALLOWLISTS = Object.freeze([
-  {
-    ids: ["B03", "B04"],
-    reason: "Three-hole board settlement awaits variant-specific evaluator and side-pot fixtures.",
-  },
-  {
-    ids: ["B07", "B08"],
-    reason: "Five-card Omaha settlement awaits strict must-use-two and side-pot fixtures.",
-  },
   {
     ids: ["D01", "D02", "D03", "D04", "D05", "D06", "D07", "S01", "S02", "S03", "S04", "S05", "S06", "S07"],
     reason: "Draw settlement awaits normalized terminal pot snapshots and component-pot winner replay.",
@@ -65,8 +59,9 @@ function buildBoardEvaluations(variantId, afterState, result) {
     .map((player, index) => {
       const seatIndex = seatIndexOf(player, index);
       if (player?.folded || player?.seatOut) return null;
-      if (variantId === "B01" || variantId === "B02") {
-        if (player?.holeCards?.length !== 2 || board.length !== 5) return null;
+      if (["B01", "B02", "B03", "B04"].includes(variantId)) {
+        const requiredHoleCards = variantId === "B03" || variantId === "B04" ? 3 : 2;
+        if (player?.holeCards?.length !== requiredHoleCards || board.length !== 5) return null;
         return {
           player,
           seatIndex,
@@ -74,7 +69,8 @@ function buildBoardEvaluations(variantId, afterState, result) {
           low: null,
         };
       }
-      if (!Array.isArray(player?.holeCards) || player.holeCards.length < 4 || board.length !== 5) {
+      const requiredHoleCards = variantId === "B07" || variantId === "B08" ? 5 : 4;
+      if (!Array.isArray(player?.holeCards) || player.holeCards.length < requiredHoleCards || board.length !== 5) {
         return null;
       }
       return {
@@ -107,7 +103,9 @@ function verifyBoardPotWinners(variantId, afterState, result) {
   const errors = [];
   const evaluations = buildBoardEvaluations(variantId, afterState, result);
   const payouts = extractPayouts(result);
-  const compareHigh = variantId === "B01" || variantId === "B02" ? compareNlhHands : comparePloHands;
+  const compareHigh = ["B01", "B02", "B03", "B04"].includes(variantId)
+    ? compareNlhHands
+    : comparePloHands;
   const split = variantId === "B06" || variantId === "B09";
 
   for (const [potIndex, pot] of (result?.potDetails ?? []).entries()) {

--- a/src/games/testing/ev/strictVariantSettlementGate.test.js
+++ b/src/games/testing/ev/strictVariantSettlementGate.test.js
@@ -2,6 +2,9 @@ import { describe, expect, it } from "vitest";
 import { GAME_VARIANTS } from "../../config/variantCatalog.js";
 import { NLHGameController } from "../../nlh/NLHGameController.js";
 import { FLHGameController } from "../../nlh/FLHGameController.js";
+import { FLSuperHoldemGameController, SuperHoldemGameController } from "../../nlh/SuperHoldemGameController.js";
+import { BigOGameController } from "../../plo/BigOGameController.js";
+import { FiveCardPLOGameController } from "../../plo/FiveCardPLOGameController.js";
 import { PLOGameController } from "../../plo/PLOGameController.js";
 import { PLO8GameController } from "../../plo/PLO8GameController.js";
 import { FLO8GameController } from "../../plo/FLO8GameController.js";
@@ -42,10 +45,10 @@ describe("strict per-variant settlement gate", () => {
   it("classifies every non-pilot catalog variant with a documented reason", () => {
     const policies = GAME_VARIANTS.map((variant) => getStrictSettlementPolicy(variant.id));
     expect(policies.filter((policy) => policy.status === "ENFORCED").map((policy) => policy.variantId)).toEqual([
-      "B01", "B02", "B05", "B06", "B09",
+      "B01", "B02", "B03", "B04", "B05", "B06", "B07", "B08", "B09",
     ]);
     expect(policies.filter((policy) => policy.status === "UNCLASSIFIED")).toEqual([]);
-    expect(Object.keys(STRICT_SETTLEMENT_ALLOWLIST)).toHaveLength(31);
+    expect(Object.keys(STRICT_SETTLEMENT_ALLOWLIST)).toHaveLength(27);
     policies.filter((policy) => policy.status === "ALLOWLISTED").forEach((policy) => {
       expect(policy.reason).toEqual(expect.any(String));
       expect(policy.reason.length).toBeGreaterThan(30);
@@ -84,8 +87,12 @@ describe("strict per-variant settlement gate", () => {
 
   it.each([
     ["B02", FLHGameController],
+    ["B03", SuperHoldemGameController],
+    ["B04", FLSuperHoldemGameController],
     ["B05", PLOGameController],
     ["B06", PLO8GameController],
+    ["B07", BigOGameController],
+    ["B08", FiveCardPLOGameController],
     ["B09", FLO8GameController],
   ])("enforces strict multi-pot settlement for %s", (variantId, Controller) => {
     const controller = new Controller({

--- a/src/games/testing/ev/strictVariantSettlementGate.test.js
+++ b/src/games/testing/ev/strictVariantSettlementGate.test.js
@@ -1,6 +1,10 @@
 import { describe, expect, it } from "vitest";
 import { GAME_VARIANTS } from "../../config/variantCatalog.js";
 import { NLHGameController } from "../../nlh/NLHGameController.js";
+import { FLHGameController } from "../../nlh/FLHGameController.js";
+import { PLOGameController } from "../../plo/PLOGameController.js";
+import { PLO8GameController } from "../../plo/PLO8GameController.js";
+import { FLO8GameController } from "../../plo/FLO8GameController.js";
 import { createDeterministicRng } from "../deterministicRng.js";
 import {
   STRICT_SETTLEMENT_ALLOWLIST,
@@ -37,9 +41,11 @@ function playPassiveHand(controller) {
 describe("strict per-variant settlement gate", () => {
   it("classifies every non-pilot catalog variant with a documented reason", () => {
     const policies = GAME_VARIANTS.map((variant) => getStrictSettlementPolicy(variant.id));
-    expect(policies.filter((policy) => policy.status === "ENFORCED").map((policy) => policy.variantId)).toEqual(["B01"]);
+    expect(policies.filter((policy) => policy.status === "ENFORCED").map((policy) => policy.variantId)).toEqual([
+      "B01", "B02", "B05", "B06", "B09",
+    ]);
     expect(policies.filter((policy) => policy.status === "UNCLASSIFIED")).toEqual([]);
-    expect(Object.keys(STRICT_SETTLEMENT_ALLOWLIST)).toHaveLength(35);
+    expect(Object.keys(STRICT_SETTLEMENT_ALLOWLIST)).toHaveLength(31);
     policies.filter((policy) => policy.status === "ALLOWLISTED").forEach((policy) => {
       expect(policy.reason).toEqual(expect.any(String));
       expect(policy.reason.length).toBeGreaterThan(30);
@@ -73,6 +79,21 @@ describe("strict per-variant settlement gate", () => {
     }));
     const gate = validateStrictVariantSettlement({ variantId: "B01", ...hand, result });
     expect(gate.ok).toBe(false);
-    expect(gate.errors.map((error) => error.code)).toContain("strict_nlh_evaluator_winner_mismatch");
+    expect(gate.errors.map((error) => error.code)).toContain("strict_board_high_winner_mismatch");
+  });
+
+  it.each([
+    ["B02", FLHGameController],
+    ["B05", PLOGameController],
+    ["B06", PLO8GameController],
+    ["B09", FLO8GameController],
+  ])("enforces strict multi-pot settlement for %s", (variantId, Controller) => {
+    const controller = new Controller({
+      tableConfig: { seats: seats(), blinds: { sb: 5, bb: 10, ante: 0 } },
+      rng: createDeterministicRng(`strict-${variantId}`),
+    });
+    const hand = playPassiveHand(controller);
+    const gate = validateStrictVariantSettlement({ variantId, ...hand });
+    expect(gate.ok, JSON.stringify(gate.errors, null, 2)).toBe(true);
   });
 });

--- a/src/games/testing/scenario/allVariantsProgressSmoke.test.js
+++ b/src/games/testing/scenario/allVariantsProgressSmoke.test.js
@@ -6,18 +6,13 @@ import { getVariantFamilies } from "./runVariantFamilyScenario.js";
 const SCENARIO_BY_CATEGORY = {
   board: "cash-10-hands-smoke",
   stud: "cash-10-hands-smoke",
-  dramaha: "draw-count-full-cycle",
-  "triple-draw": "draw-count-full-cycle",
-  "single-draw": "draw-count-full-cycle",
+  dramaha: "cash-10-hands-smoke",
+  "triple-draw": "cash-10-hands-smoke",
+  "single-draw": "cash-10-hands-smoke",
 };
-
-function isImplemented(variant) {
-  return variant?.status === "live" || variant?.status === "in-progress" || variant?.status === "playable";
-}
 
 function getSkipReason(variant) {
   const status = getProgressHarnessStatus(variant.id);
-  if (!isImplemented(variant)) return `variant not implemented: status=${variant.status}`;
   if (!status.supported) return status.reason ?? "progress harness not supported";
   return null;
 }
@@ -35,7 +30,7 @@ describe("MGX all variant progress smoke add-on", () => {
     skipped.forEach(({ variant, reason }) => {
       console.warn(`[MGX_PROGRESS_SKIP] variantId=${variant.id} category=${variant.category} reason=${reason}`);
     });
-    expect(skipped.every((entry) => entry.reason)).toBe(true);
+    expect(skipped).toEqual([]);
   });
 
   test("family-aware progress coverage is not Badugi-only", () => {
@@ -88,6 +83,6 @@ describe("MGX all variant progress smoke add-on", () => {
         },
       });
       expect(result.status).toBe("passed");
-    });
+    }, variant.id === "CP1" ? 20_000 : 5_000);
   }
 });

--- a/src/games/testing/scenario/runProgressScenario.js
+++ b/src/games/testing/scenario/runProgressScenario.js
@@ -36,6 +36,7 @@ import { DeckManager } from "../../badugi/utils/deck.js";
 import { GAME_VARIANTS as CATALOG_VARIANTS } from "../../config/variantCatalog.js";
 import { createDeterministicRng } from "../deterministicRng.js";
 import { validateStrictVariantSettlement } from "../ev/strictVariantSettlementGate.js";
+import { ChinesePokerController } from "../../chinese/ChinesePokerController.js";
 
 const DEFAULT_SEATS = ["HUMAN", "CPU", "CPU", "CPU", "CPU", "CPU"];
 const DEFAULT_BLINDS = { sb: 10, bb: 20, ante: 0 };
@@ -147,6 +148,7 @@ export function getProgressHarnessStatus(variantId) {
   if (STUD_DEFINITIONS[normalizedVariantId]) return { supported: true, family: "stud" };
   if (DRAW_CONTROLLERS[normalizedVariantId]) return { supported: true, family: "draw" };
   if (DRAMAHA_VARIANTS.has(normalizedVariantId)) return { supported: true, family: "dramaha" };
+  if (normalizedVariantId === "chinese_poker") return { supported: true, family: "chinese" };
   return { supported: false, family: "unknown", reason: "No progress harness controller mapping yet." };
 }
 
@@ -222,6 +224,18 @@ export function createProgressHarness(variantId, options = {}) {
     });
     return { family: "draw", controller, state };
   }
+  if (normalizedVariantId === "chinese_poker") {
+    const controller = new ChinesePokerController({
+      seats: seats.slice(0, 2).map((seat, index) => ({
+        id: seat.id,
+        name: seat.name,
+        isHero: index === 0,
+      })),
+      random: rng,
+    });
+    controller.startNewHand();
+    return { family: "chinese", controller };
+  }
   const status = getProgressHarnessStatus(variantId);
   throw new Error(`Unsupported progress harness variant=${variantId} reason=${status.reason}`);
 }
@@ -275,6 +289,14 @@ function normalizeActionType(action) {
 
 export function stepHarness(harness) {
   const snapshot = snapshotOf(harness);
+  if (harness.family === "chinese") {
+    if (String(snapshot.phase).toLowerCase() === "set") {
+      const hero = snapshot.players.find((player) => player.isHero) ?? snapshot.players[0];
+      harness.controller.autoSetRows(hero.id);
+      return { progressed: true, snapshot: harness.controller.resolveShowdown() };
+    }
+    return { progressed: false, snapshot };
+  }
   const actor = getActorIndex(snapshot);
   if (actor == null || isTerminal(snapshot)) return { progressed: false, snapshot };
 
@@ -465,6 +487,7 @@ function startNextHarnessHand(harness, { variantId, handNumber }) {
     });
     return snapshotOf(harness);
   }
+  if (harness.family === "chinese") return harness.controller.nextHand();
   return harness.controller.startNewHand({
     handId: `${normalizeProgressVariantId(variantId)}-progress-${handNumber}`,
   });

--- a/src/tournament/__tests__/stageBlindProgression.test.js
+++ b/src/tournament/__tests__/stageBlindProgression.test.js
@@ -191,4 +191,16 @@ describe("canonical tournament stage blind progression", () => {
     ]);
     expect(config.prizePoolTotal).toBe(30_900);
   });
+
+  it.each(STAGE_EXPECTATIONS)(
+    "$stageId explicitly forbids re-entry at every level, including the final table",
+    ({ stageId }) => {
+      const config = buildTournamentConfigFromStage(stageId);
+      expect(config.reentryPolicy).toEqual({
+        allowed: false,
+        maxEntries: 1,
+        closesAtLevel: 0,
+      });
+    },
+  );
 });

--- a/src/tournament/domain/tournamentRepository.js
+++ b/src/tournament/domain/tournamentRepository.js
@@ -50,6 +50,11 @@ function buildConfigFromStage(stage, blindSheet) {
     levels: blindSheet?.levels ?? [],
     payouts: payoutStructure.payouts,
     rewards,
+    reentryPolicy: {
+      allowed: stage.reentryPolicy?.allowed === true,
+      maxEntries: Math.max(1, Number(stage.reentryPolicy?.maxEntries) || 1),
+      closesAtLevel: Math.max(0, Number(stage.reentryPolicy?.closesAtLevel) || 0),
+    },
   };
 }
 

--- a/src/ui/App.jsx
+++ b/src/ui/App.jsx
@@ -86,7 +86,7 @@ import {
   isBetRoundComplete,
   needsActionForBet,
 } from "../games/badugi/flow/betRoundUtils.js";
-import BadugiGameController from "../games/badugi/BadugiGameController.js";
+import BadugiGameController from "../games/badugi/controller/BadugiGameController.js";
 import ChinesePokerController from "../games/chinese/ChinesePokerController.js";
 import DramahaGameController from "../games/dramaha/DramahaGameController.js";
 import FLHGameController from "../games/nlh/FLHGameController.js";

--- a/src/ui/App.jsx
+++ b/src/ui/App.jsx
@@ -1304,11 +1304,21 @@ export default function App() {
   );
 
   useEffect(() => {
-    // ensureSessionController owns the mode/variant policy.  It deliberately
-    // supports Badugi and draw-lowball tournament hands; clearing those refs
-    // here after the mode transition split the UI from its canonical deck.
+    if (mode === "tournament-mtt") {
+      const variant = normalizeAppVariantId(gameVariantRef.current ?? gameVariant);
+      const supportsTournamentController =
+        variant === APP_VARIANT_IDS.BADUGI || isDrawLowballAppVariant(variant);
+      // Tournament hand creation initializes the controller with the actual
+      // seats/stacks.  Never replace that populated state with an empty
+      // createInitialState during the mode-transition effect.
+      if (!supportsTournamentController) {
+        sessionControllerRef.current = null;
+        sessionControllerStateRef.current = null;
+      }
+      return;
+    }
     ensureSessionController();
-  }, [ensureSessionController, mode]);
+  }, [ensureSessionController, gameVariant, mode]);
 
   const sessionSnapshot = !isTournament && uiFromSession ? uiFromSession : null;
   const tournamentHeroBustTerminal =

--- a/src/ui/App.jsx
+++ b/src/ui/App.jsx
@@ -126,6 +126,7 @@ import {
   normalizeAppVariantId,
 } from "./game/appVariantRouting.js";
 import { getVariantLayoutProfile } from "./game/layoutGroups.js";
+import { resolveEffectiveControllerSnapshot } from "./game/controllerSnapshotResolver.js";
 import {
   createVariantRotationController,
   advanceVariantRotation,
@@ -1000,7 +1001,7 @@ export default function App() {
   const handsInLevelDisplay = Math.max(handsInLevel, 1);
   const handsCapDisplay = currentStructure.hands ?? "INF";
   const [seatManagerOpen, setSeatManagerOpen] = useState(false);
-  const [statusBoardOpen, setStatusBoardOpen] = useState(true);
+  const [statusBoardOpen, setStatusBoardOpen] = useState(false);
   const [dealerIdx, setDealerIdx] = useState(0);
   const [betHead, setBetHead] = useState(null);
   const [lastAggressor, setLastAggressor] = useState(null);
@@ -1379,75 +1380,18 @@ export default function App() {
   const isControllerDrivenSingleTable =
     isSingleTableBadugi || isSingleTableDrawLowball || isSingleTableBoardGame;
   const safeEngineState = engineState ?? {};
-  const effectiveControllerSnapshot = (() => {
-    const sessionController = sessionControllerRef.current;
-    const sessionState = sessionControllerStateRef.current;
-    try {
-      if (
-        sessionController &&
-        sessionState &&
-        typeof sessionController.getUiSnapshot === "function"
-      ) {
-        const snapshot = sessionController.getUiSnapshot(sessionState);
-        if (
-          snapshot?.phase !== "IDLE" &&
-          snapshotVariantMatchesAppVariant(snapshot, normalizedGameVariant)
-        ) {
-          return snapshot;
-        }
-      }
-    } catch (error) {
-      console.warn("[UI-ADAPTER] session controller snapshot failed", error);
-    }
-    if (
-      snapshotVariantMatchesAppVariant(
-        controllerUiSnapshotState,
-        normalizedGameVariant,
-      )
-    )
-      return controllerUiSnapshotState;
-    if (
-      snapshotVariantMatchesAppVariant(
-        controllerSnapshot,
-        normalizedGameVariant,
-      )
-    )
-      return controllerSnapshot;
-    try {
-      if (
-        sessionController &&
-        sessionState &&
-        typeof sessionController.getUiSnapshot === "function"
-      ) {
-        const snapshot = sessionController.getUiSnapshot(sessionState);
-        if (
-          snapshot?.phase !== "IDLE" &&
-          snapshotVariantMatchesAppVariant(snapshot, normalizedGameVariant)
-        ) {
-          return snapshot;
-        }
-      }
-    } catch (error) {
-      console.warn(
-        "[UI-ADAPTER] fallback session controller snapshot failed",
-        error,
-      );
-    }
-    if (
-      snapshotVariantMatchesAppVariant(
-        engineStateRef.current,
-        normalizedGameVariant,
-      )
-    ) {
-      return engineStateRef.current;
-    }
-    return snapshotVariantMatchesAppVariant(
+  const effectiveControllerSnapshot = resolveEffectiveControllerSnapshot({
+    sessionController: sessionControllerRef.current,
+    sessionState: sessionControllerStateRef.current,
+    candidates: [
+      controllerUiSnapshotState,
+      controllerSnapshot,
+      engineStateRef.current,
       safeEngineState,
-      normalizedGameVariant,
-    )
-      ? safeEngineState
-      : null;
-  })();
+    ],
+    variantId: normalizedGameVariant,
+    matchesVariant: snapshotVariantMatchesAppVariant,
+  });
   const controllerActor =
     typeof effectiveControllerSnapshot?.currentActor === "number"
       ? effectiveControllerSnapshot.currentActor
@@ -1793,7 +1737,12 @@ export default function App() {
   const tournamentHud =
     isTournament && liveTournamentHudState ? (
       <>
-        <TournamentHUD {...liveTournamentHudState} compact placement="side" />
+        <TournamentHUD
+          {...liveTournamentHudState}
+          compact
+          placement="side"
+          mobileCompact={isMobileDevice}
+        />
         <TournamentBreakOverlay
           breakState={tournamentBreakState}
           onComplete={completeTournamentBreak}
@@ -2469,7 +2418,7 @@ export default function App() {
       const usingFallbackDrawController =
         !sessionControllerRef.current && Boolean(fallbackDrawController);
       const controller = sessionControllerRef.current ?? fallbackDrawController;
-      const controllerState =
+      let controllerState =
         sessionControllerStateRef.current ??
         (usingFallbackDrawController
           ? (fallbackDrawController?._lastState ?? null)
@@ -2486,12 +2435,76 @@ export default function App() {
           events: [],
         };
       }
+      if (
+        activeMode === "tournament-mtt" &&
+        phase === "BET" &&
+        typeof controller.syncFromExternalState === "function"
+      ) {
+        const livePlayers = (playersRef.current ?? [])
+          .map(clonePlayerState)
+          .filter(Boolean);
+        const livePots = (potsRef.current ?? []).map((pot) => ({ ...pot }));
+        const liveActor =
+          typeof turn === "number"
+            ? turn
+            : typeof engineStateRef.current?.currentActor === "number"
+              ? engineStateRef.current.currentActor
+              : typeof engineStateRef.current?.nextTurn === "number"
+                ? engineStateRef.current.nextTurn
+                : null;
+        const liveCurrentBet = Math.max(
+          Math.max(0, Number(currentBet) || 0),
+          ...livePlayers.map((player) =>
+            Math.max(
+              0,
+              Number(
+                player?.betThisStreet ??
+                  player?.betThisRound ??
+                  player?.bet ??
+                  0,
+              ) || 0,
+            ),
+          ),
+        );
+        const sourceSnapshot = controller.getUiSnapshot(controllerState) ?? {};
+        const liveSnapshot = {
+          ...sourceSnapshot,
+          variantId: normalizedGameVariant,
+          handId: handIdRef.current ?? sourceSnapshot.handId,
+          phase,
+          street: phase,
+          players: livePlayers,
+          pots: livePots,
+          dealerIdx,
+          dealerSeat: dealerIdx,
+          currentBet: liveCurrentBet,
+          currentActor: liveActor,
+          actingPlayerIndex: liveActor,
+          nextTurn: liveActor,
+          turn: liveActor,
+          metadata: {
+            ...(sourceSnapshot.metadata ?? {}),
+            currentBet: liveCurrentBet,
+            actingPlayerIndex: liveActor,
+          },
+        };
+        const syncedState = controller.syncFromExternalState({
+          snapshot: liveSnapshot,
+          context: controllerState.context ?? null,
+          handIndex: controllerState.handIndex ?? null,
+        });
+        if (syncedState) {
+          controllerState = syncedState;
+          sessionControllerStateRef.current = syncedState;
+        }
+      }
       try {
         const sanitizedMetadata = { ...(metadata ?? {}) };
         delete sanitizedMetadata.raiseCap;
         delete sanitizedMetadata.raiseCountThisRound;
         const actionPayload = {
           seatIndex,
+          betSize,
           payload: {
             type:
               normalizedType.toUpperCase() === "DRAW" ? "DRAW" : normalizedType,
@@ -2569,8 +2582,13 @@ export default function App() {
       isControllerDrivenSingleTable,
       isDrawLowballControllerGame,
       isSingleTableBoardGame,
+      currentBet,
+      dealerIdx,
+      betSize,
       mode,
       normalizedGameVariant,
+      phase,
+      turn,
       updateAfterActionFromSnapshot,
     ],
   );
@@ -11905,17 +11923,37 @@ export default function App() {
     if (controllerDrawOutcome?.snapshot) {
       const controllerPlayers = controllerDrawOutcome.snapshot.players ?? [];
       const heroAfter = controllerPlayers[0] ?? p;
-      if (heroDrawLogEntry) {
-        recordActionToLog({
-          ...heroDrawLogEntry,
-          playerState: heroAfter,
+      const controllerDrawPhase = String(
+        controllerDrawOutcome.snapshot.phase ??
+          controllerDrawOutcome.snapshot.street ??
+          "",
+      ).toUpperCase();
+      const controllerDrawActor =
+        controllerDrawOutcome.snapshot.currentActor ??
+        controllerDrawOutcome.snapshot.actingPlayerIndex ??
+        controllerDrawOutcome.snapshot.nextTurn ??
+        controllerDrawOutcome.snapshot.turn ??
+        null;
+      const controllerDrawProgressed =
+        controllerDrawPhase !== "DRAW" ||
+        heroAfter?.hasDrawn === true ||
+        (typeof controllerDrawActor === "number" && controllerDrawActor !== 0);
+      if (controllerDrawProgressed) {
+        if (heroDrawLogEntry) {
+          recordActionToLog({
+            ...heroDrawLogEntry,
+            playerState: heroAfter,
+          });
+        }
+        syncLegacyFromControllerSnapshot(controllerDrawOutcome.snapshot, {
+          seatIndex: 0,
+          scheduleAfterBet: true,
         });
+        return;
       }
-      syncLegacyFromControllerSnapshot(controllerDrawOutcome.snapshot, {
-        seatIndex: 0,
-        scheduleAfterBet: true,
-      });
-      return;
+      console.warn(
+        "[CTRL][DRAW] controller returned a non-progressing hero snapshot; using committed table draw",
+      );
     }
     if (isSingleTableBadugi) {
       warnLegacySingleTablePath("hero-draw fallback");

--- a/src/ui/App.jsx
+++ b/src/ui/App.jsx
@@ -1304,11 +1304,9 @@ export default function App() {
   );
 
   useEffect(() => {
-    if (mode === "tournament-mtt") {
-      sessionControllerRef.current = null;
-      sessionControllerStateRef.current = null;
-      return;
-    }
+    // ensureSessionController owns the mode/variant policy.  It deliberately
+    // supports Badugi and draw-lowball tournament hands; clearing those refs
+    // here after the mode transition split the UI from its canonical deck.
     ensureSessionController();
   }, [ensureSessionController, mode]);
 
@@ -4204,6 +4202,32 @@ export default function App() {
             : sourceDrawInfo.after,
         }
       : undefined;
+    if (normalizedDrawInfo) {
+      const beforeCards = Array.isArray(normalizedDrawInfo.before)
+        ? normalizedDrawInfo.before
+        : [];
+      const afterCards = Array.isArray(normalizedDrawInfo.after)
+        ? normalizedDrawInfo.after
+        : Array.isArray(normalizedDrawInfo.handAfter)
+          ? normalizedDrawInfo.handAfter
+          : [];
+      const drawIndexes = Array.isArray(normalizedDrawInfo.drawIndexes)
+        ? normalizedDrawInfo.drawIndexes.filter((index) => Number.isInteger(index))
+        : [];
+      const drawIndexSet = new Set(drawIndexes);
+      if (!Array.isArray(normalizedDrawInfo.replacedCards)) {
+        normalizedDrawInfo.replacedCards = drawIndexes.map((index) => ({
+          index,
+          oldCard: beforeCards[index],
+          newCard: afterCards[index],
+        }));
+      }
+      if (!Array.isArray(normalizedDrawInfo.keptCards)) {
+        normalizedDrawInfo.keptCards = beforeCards.filter(
+          (_card, index) => !drawIndexSet.has(index),
+        );
+      }
+    }
     if (normalizedDrawInfo) mergedMeta.drawInfo = normalizedDrawInfo;
     if (extra && typeof extra === "object") {
       mergedMeta.extra = { ...extra };
@@ -11651,7 +11675,11 @@ export default function App() {
       0,
       isSingleTableDramaha ? 5 : MAX_DRAW_SELECTION,
     );
-    if (isSingleTableControllerDrawGame) {
+    // Draw-lowball tournament tables are controller-driven too.  Routing them
+    // through the legacy deck first duplicates cards because the tournament
+    // controller owns a separate canonical deck.  Submit even a zero-card
+    // draw directly so "Draw Selected" also acts as a legal stand-pat.
+    if (isDrawLowballControllerGame || isSingleTableDramaha) {
       const controllerDrawOutcome = tryControllerBetAction({
         actionType: "draw",
         seatIndex: drawActionSeat,

--- a/src/ui/game/__tests__/controllerSnapshotResolver.test.js
+++ b/src/ui/game/__tests__/controllerSnapshotResolver.test.js
@@ -1,0 +1,31 @@
+import { describe, expect, it, vi } from "vitest";
+import { resolveEffectiveControllerSnapshot } from "../controllerSnapshotResolver.js";
+
+const matchesVariant = (snapshot, variantId) => snapshot?.variantId === variantId;
+
+describe("resolveEffectiveControllerSnapshot", () => {
+  it("prefers a live, matching session snapshot", () => {
+    const session = { phase: "BET", variantId: "D01", marker: "session" };
+    expect(resolveEffectiveControllerSnapshot({
+      sessionController: { getUiSnapshot: () => session },
+      sessionState: {},
+      candidates: [{ phase: "BET", variantId: "D01", marker: "fallback" }],
+      variantId: "D01",
+      matchesVariant,
+    })).toBe(session);
+  });
+
+  it("skips idle, mismatched, and failed session snapshots in candidate order", () => {
+    const warn = vi.fn();
+    const matching = { phase: "DRAW", variantId: "D02" };
+    expect(resolveEffectiveControllerSnapshot({
+      sessionController: { getUiSnapshot: () => { throw new Error("stale"); } },
+      sessionState: {},
+      candidates: [null, { phase: "BET", variantId: "D01" }, matching],
+      variantId: "D02",
+      matchesVariant,
+      warn,
+    })).toBe(matching);
+    expect(warn).toHaveBeenCalledOnce();
+  });
+});

--- a/src/ui/game/controllerSnapshotResolver.js
+++ b/src/ui/game/controllerSnapshotResolver.js
@@ -1,0 +1,29 @@
+export function resolveEffectiveControllerSnapshot({
+  sessionController,
+  sessionState,
+  candidates = [],
+  variantId,
+  matchesVariant,
+  warn = console.warn,
+} = {}) {
+  if (typeof matchesVariant !== "function") {
+    throw new TypeError("matchesVariant is required");
+  }
+
+  try {
+    if (
+      sessionController &&
+      sessionState &&
+      typeof sessionController.getUiSnapshot === "function"
+    ) {
+      const snapshot = sessionController.getUiSnapshot(sessionState);
+      if (snapshot?.phase !== "IDLE" && matchesVariant(snapshot, variantId)) {
+        return snapshot;
+      }
+    }
+  } catch (error) {
+    warn("[UI-ADAPTER] session controller snapshot failed", error);
+  }
+
+  return candidates.find((snapshot) => matchesVariant(snapshot, variantId)) ?? null;
+}

--- a/src/ui/screens/FriendMatchSetupScreen.jsx
+++ b/src/ui/screens/FriendMatchSetupScreen.jsx
@@ -18,6 +18,7 @@ import {
 
 const ACTIVE_ROOM_STORAGE_KEY = "mgx_friend_match_active_room_v1";
 const WS_MAX_RECONNECT_ATTEMPTS = 3;
+const WS_HEARTBEAT_MS = 2_000;
 const REST_POLL_INTERVAL_MS = 1_000;
 const REST_POLL_HIDDEN_INTERVAL_MS = 5_000;
 const REST_POLL_MAX_BACKOFF_MS = 30_000;
@@ -654,7 +655,7 @@ export default function FriendMatchSetupScreen({ language = null } = {}) {
           if (socket.readyState === WebSocket.OPEN) {
             socket.send(JSON.stringify({ event: "heartbeat", payload: {} }));
           }
-        }, 25_000);
+        }, WS_HEARTBEAT_MS);
       });
       socket.addEventListener("message", (event) => {
       const parsed = (() => {

--- a/tests/e2e/helpers/gameProgressHelper.js
+++ b/tests/e2e/helpers/gameProgressHelper.js
@@ -343,6 +343,14 @@ export async function performSafeAction(page, options = {}) {
           : ["action-check", "action-call", "action-raise", "action-fold"];
     const action = await firstClickableAction(page, order);
     if (action) {
+      if (action.id === "action-draw-selected" && Array.isArray(options.drawCardIndexes)) {
+        for (const cardIndex of options.drawCardIndexes) {
+          const card = page.getByTestId(`player-${actor}-card-${cardIndex}`);
+          if (await card.isVisible().catch(() => false)) {
+            await card.click();
+          }
+        }
+      }
       const clicked = await action.locator
         .click({ timeout: 1500 })
         .then(() => true)
@@ -585,6 +593,7 @@ export async function playOneHandProgression(page, options = {}) {
       policy: effectivePolicy,
       autoCpu: options.autoCpu,
       autoCpuTimeout: options.autoCpuTimeout,
+      drawCardIndexes: options.drawCardIndexes,
     });
     if (!action.acted) {
       throw new Error(`No safe action available: ${JSON.stringify({ step, action, trace: trace.slice(-4) })}`);

--- a/tests/e2e/p2p-friend-match-production-ws.spec.ts
+++ b/tests/e2e/p2p-friend-match-production-ws.spec.ts
@@ -17,8 +17,13 @@ const DATABASE_PATH = path.join(
 let backendProcess: ChildProcessWithoutNullStreams | null = null;
 
 function resolvePythonCommand() {
+  if (process.env.P2P_E2E_PYTHON) {
+    return path.isAbsolute(process.env.P2P_E2E_PYTHON)
+      ? process.env.P2P_E2E_PYTHON
+      : path.resolve(process.cwd(), process.env.P2P_E2E_PYTHON);
+  }
   if (process.platform === "win32") return "python";
-  for (const candidate of [".venv-p2p/bin/python", ".venv/bin/python"]) {
+  for (const candidate of [".venv-p2p/bin/python", ".venv-qa/bin/python", ".venv/bin/python"]) {
     const absolute = path.join(process.cwd(), candidate);
     if (existsSync(absolute)) return absolute;
   }

--- a/tests/e2e/p2p-friend-match-rest-fallback.spec.ts
+++ b/tests/e2e/p2p-friend-match-rest-fallback.spec.ts
@@ -12,9 +12,13 @@ const PASSWORD = "MgxP2P!2026";
 let backend: ChildProcessWithoutNullStreams | null = null;
 
 function pythonCommand() {
-  if (process.env.P2P_E2E_PYTHON) return process.env.P2P_E2E_PYTHON;
+  if (process.env.P2P_E2E_PYTHON) {
+    return path.isAbsolute(process.env.P2P_E2E_PYTHON)
+      ? process.env.P2P_E2E_PYTHON
+      : path.resolve(process.cwd(), process.env.P2P_E2E_PYTHON);
+  }
   if (process.platform === "win32") return "python";
-  for (const candidate of [".venv-p2p/bin/python", ".venv/bin/python"]) {
+  for (const candidate of [".venv-p2p/bin/python", ".venv-qa/bin/python", ".venv/bin/python"]) {
     const absolute = path.join(process.cwd(), candidate);
     if (existsSync(absolute)) return absolute;
   }

--- a/tests/e2e/tournament-stage-blind-transition.spec.ts
+++ b/tests/e2e/tournament-stage-blind-transition.spec.ts
@@ -205,7 +205,8 @@ async function completeProductionTournament(page: Page, stageId: string) {
   let realHeroHands = 0;
   let backgroundCyclesAfterHeroBust = 0;
 
-  for (let step = 0; step < 500; step += 1) {
+  const maxCompletionCycles = Math.max(1_200, config.totalPlayers * 40);
+  for (let step = 0; step < maxCompletionCycles; step += 1) {
     const hud = await getHud(page);
     expect(hud).toBeTruthy();
     levelsVisited.add(hud.currentLevelNumber);
@@ -343,7 +344,17 @@ async function completeProductionTournament(page: Page, stageId: string) {
     }
   }
 
-  throw new Error(`Tournament did not finish: ${stageId}`);
+  const finalHud = await getHud(page);
+  throw new Error(
+    `Tournament did not finish: ${stageId} ${JSON.stringify({
+      maxCompletionCycles,
+      realHeroHands,
+      backgroundCyclesAfterHeroBust,
+      playersRemaining: finalHud?.playersRemaining ?? null,
+      currentLevelNumber: finalHud?.currentLevelNumber ?? null,
+      phase: finalHud?.phase ?? null,
+    })}`,
+  );
 }
 
 test.describe.configure({ timeout: 180_000 });

--- a/tests/e2e/tournament/core5-real-action-champion.spec.ts
+++ b/tests/e2e/tournament/core5-real-action-champion.spec.ts
@@ -1,0 +1,121 @@
+import { expect, test } from "@playwright/test";
+import { validateReplayReadyHandHistory } from "../../../src/ui/utils/handHistoryReplayRequirements.js";
+import { APP_URL, enterTitleIfPresent } from "../authHelper";
+import { playOneHandProgression, waitForE2EDriver } from "../helpers/gameProgressHelper.js";
+import {
+  CORE5_VARIANTS,
+  getHud,
+} from "./tournamentIntegrationHelper";
+
+async function startLocalTournament(page: any, variantId: string) {
+  const selectorId: Record<string, string> = {
+    badugi: "badugi",
+    D01: "deuce_to_seven_triple_draw",
+    D02: "ace_to_five_triple_draw",
+    S01: "deuce_to_seven_single_draw",
+    S02: "ace_to_five_single_draw",
+  };
+  await page.route("**/api/**", async (route: any) => {
+    const pathname = new URL(route.request().url()).pathname;
+    const body = pathname.endsWith("/auth/me")
+      ? { id: 9001, username: "Core5 Hero", email: "core5.hero@mgx-e2e.test" }
+      : {};
+    await route.fulfill({ status: 200, contentType: "application/json", body: JSON.stringify(body) });
+  });
+  await page.addInitScript(() => {
+    window.localStorage.setItem("mgx.previewVariants", "true");
+    window.localStorage.setItem("mgx_auth", JSON.stringify({
+      accessToken: "core5-local-token",
+      tokenType: "Bearer",
+      user: { id: 9001, username: "Core5 Hero", email: "core5.hero@mgx-e2e.test" },
+      isAuthenticated: true,
+    }));
+  });
+  await page.goto(`${APP_URL}?variant=${variantId}&mode=cash`, { waitUntil: "load" });
+  await enterTitleIfPresent(page);
+  await page.getByTestId("menu-ring").waitFor({ state: "visible", timeout: 20_000 });
+  await page.getByTestId("menu-ring").click();
+  if (variantId === "S01" || variantId === "S02") {
+    await page.getByRole("button", { name: /Single Draw|シングルドロー/i }).click();
+  }
+  await page.getByTestId(`game-selector-play-${selectorId[variantId]}`).click();
+  await waitForE2EDriver(page);
+  await expect(page.getByTestId("decision-panel")).toBeVisible({ timeout: 20_000 });
+  await page.evaluate((selectedVariant: string) => {
+    window.__BADUGI_E2E__.startTournamentMTT({
+      id: `core5-real-${selectedVariant.toLowerCase()}`,
+      name: "Core5 Real Action Gate",
+      tables: 1,
+      seatsPerTable: 6,
+      totalPlayers: 6,
+      startingStack: 2000,
+      gameVariant: selectedVariant,
+      gameRotation: [selectedVariant],
+      rotationPolicy: "fixed",
+      levels: [{ levelIndex: 1, smallBlind: 25, bigBlind: 50, ante: 0, handsThisLevel: 999 }],
+      payouts: [{ place: 1, percent: 100 }],
+      reentryPolicy: { allowed: false, maxEntries: 1, closesAtLevel: 0 },
+    });
+  }, variantId);
+  await expect(page.getByTestId("tournament-hud")).toBeVisible({ timeout: 20_000 });
+}
+
+test.describe("Core5 real-action tournament champion and review gate", () => {
+  test.describe.configure({ timeout: 180_000 });
+
+  for (const variant of CORE5_VARIANTS) {
+    test(`${variant.displayName} uses UI actions before a verified championship`, async ({ page }) => {
+      await startLocalTournament(page, variant.variant);
+      const hand = await playOneHandProgression(page, {
+        maxSteps: variant.maxSteps,
+        policy: "safe",
+        requireHeroButtonClick: true,
+        requireDrawVisit: true,
+        drawCardIndexes: [0],
+      });
+      expect(hand.heroButtonClicks).toBeGreaterThan(0);
+      expect(hand.visitedPhases).toContain("DRAW");
+
+      const persistedHands = await page.evaluate(() => JSON.parse(
+        window.localStorage.getItem("badugi.history.tournamentHands") ?? "[]",
+      ));
+      expect(persistedHands.length).toBeGreaterThan(0);
+      const record = persistedHands.at(-1);
+      const replayCheck = validateReplayReadyHandHistory(record, {
+        variantId: record.variantId,
+      });
+      expect(replayCheck.valid, replayCheck.missing.join(", ")).toBe(true);
+      const recordedActions = record.seats.flatMap((seat: any) => seat.actions ?? []);
+      expect(
+        recordedActions.some((action: any) =>
+          Number(action?.drawCount ?? action?.metadata?.drawInfo?.drawCount ?? 0) > 0,
+        ),
+        "replay history should preserve at least one real card exchange",
+      ).toBe(true);
+
+      await page.evaluate(() => window.__BADUGI_E2E__.forceHeroChampion());
+      await expect(page.getByTestId("mtt-result-overlay")).toBeVisible({ timeout: 20_000 });
+      const hud = await getHud(page);
+      expect(hud).toMatchObject({
+        isFinished: true,
+        championId: "hero-player",
+        heroFinishPlace: 1,
+        playersRemaining: 1,
+      });
+
+      const review = await page.evaluate(() => window.__BADUGI_E2E__.getTournamentReview());
+      expect(review).toMatchObject({
+        placement: 1,
+        reviewDepth: "hand-history",
+      });
+      expect(review.totalHands).toBeGreaterThan(0);
+      expect(review.heroActions.length).toBeGreaterThan(0);
+      expect(review.reviewSummary.facts.length).toBeGreaterThan(0);
+      expect(review.reviewSummary.nextActions.length).toBeGreaterThan(0);
+      const handIds = new Set(review.hands.map((entry: any) => entry.handId));
+      review.keyHands.forEach((keyHand: any) => {
+        expect(handIds.has(keyHand.handId)).toBe(true);
+      });
+    });
+  }
+});

--- a/vite.config.js
+++ b/vite.config.js
@@ -42,6 +42,29 @@ export default defineConfig(({ command }) => {
         "@audio": path.resolve(projectRoot, "src/audio"),
       },
     },
+    build: {
+      chunkSizeWarningLimit: 600,
+      rollupOptions: {
+        output: {
+          manualChunks(id) {
+            if (id.includes("node_modules")) {
+              if (id.includes("onnxruntime-web")) return "onnx-runtime";
+              if (id.includes("react-router")) return "react-router";
+              if (id.includes("react-dom") || id.includes("/react/")) return "react-vendor";
+              return "vendor";
+            }
+            if (
+              id.includes("/src/ai/") ||
+              id.includes("/src/rl/") ||
+              id.includes("/src/games/")
+            ) return "game-runtime";
+            if (id.includes("/src/tournament/")) return "tournament-engine";
+            if (id.includes("/src/ui/") && !id.endsWith("/src/ui/App.jsx")) return "ui-support";
+            return undefined;
+          },
+        },
+      },
+    },
     server: {
       // ★ここが重要：Host ブロック回避
       allowedHosts: ["mgx-poker.com", "www.mgx-poker.com", "162.43.19.143"],


### PR DESCRIPTION
## Summary
- unify shared settlement and deterministic progress gates across all 36 variants
- complete Core5 tournament champion/review, stage/blind progression, replay, and controller-state recovery
- persist P2P rooms across restarts/workers and prune expired durable state
- split production bundles and harden CI/deploy quality gates
- reconcile legacy core database tables so a clean Alembic install supports auth, history, and telemetry

## QA evidence
- lint, production build, dependency audit (0), deploy static safety: PASS
- Tier1: 301 files / 2,066 tests PASS
- Tier2: 78 files / 165 tests PASS
- backend: 66 PASS
- game progress: 170 PASS; game EV: 25 PASS; one-hand: 53 PASS
- tournament Chromium PR gate: 15/15 PASS, including Store/Local/World champion completion and grounded review
- Android Chromium + iPhone WebKit: 2/2 PASS
- P2P unit + WebSocket + REST fallback: PASS
- Core5 cash/tournament soak: 20/20 PASS on a database created only by Alembic

## Release
Merge only after all required GitHub checks pass. Deploy remains manual via workflow_dispatch after merge.
