### PR TITLE
fix(deploy): load backend environment for migrations

### DIFF
--- a/.github/workflows/deploy-mgx-prod-01.yml
+++ b/.github/workflows/deploy-mgx-prod-01.yml
@@ -128,6 +128,7 @@ jobs:
           branch="$1"
           cd /home/mgx/badugi-app
           test -z "$(git status --porcelain --untracked-files=no)"
+          test -r /etc/mgx/mgx-backend.env
           git fetch origin "$branch"
           git rev-parse --verify "origin/$branch"
           sudo -n /usr/sbin/nginx -t

--- a/backend/README.md
+++ b/backend/README.md
@@ -59,6 +59,11 @@ Then add this under `[Service]` in `/etc/systemd/system/mgx-backend.service`:
 EnvironmentFile=/etc/mgx/mgx-backend.env
 ```
 
+The production deploy helper reads this same file with `python-dotenv` before
+running Alembic. It does not evaluate the file as shell code and does not place
+secret values in process arguments or deployment logs. If production uses a
+different path, set `BACKEND_ENV_FILE` explicitly for the deploy command.
+
 Reload and restart:
 
 ```bash

--- a/backend/tests/test_deploy_env_runner.py
+++ b/backend/tests/test_deploy_env_runner.py
@@ -1,0 +1,57 @@
+from __future__ import annotations
+
+import os
+from pathlib import Path
+import subprocess
+import sys
+
+
+ROOT = Path(__file__).resolve().parents[2]
+RUNNER = ROOT / "scripts" / "deploy" / "run-with-dotenv.py"
+
+
+def test_dotenv_runner_passes_secrets_without_shell_evaluation(tmp_path: Path) -> None:
+    env_file = tmp_path / "backend.env"
+    output_file = tmp_path / "captured.txt"
+    env_file.write_text(
+        "DEPLOY_TEST_TOKEN='value with spaces $HOME ; echo unsafe'\n",
+        encoding="utf-8",
+    )
+
+    command = [
+        sys.executable,
+        str(RUNNER),
+        str(env_file),
+        sys.executable,
+        "-c",
+        (
+            "import os, pathlib, sys; "
+            "pathlib.Path(sys.argv[1]).write_text(os.environ['DEPLOY_TEST_TOKEN'])"
+        ),
+        str(output_file),
+    ]
+    completed = subprocess.run(
+        command,
+        check=False,
+        capture_output=True,
+        text=True,
+        env={**os.environ, "HOME": "/must-not-expand"},
+    )
+
+    assert completed.returncode == 0
+    assert completed.stdout == ""
+    assert completed.stderr == ""
+    assert output_file.read_text(encoding="utf-8") == "value with spaces $HOME ; echo unsafe"
+
+
+def test_dotenv_runner_fails_closed_when_file_is_missing(tmp_path: Path) -> None:
+    missing = tmp_path / "missing.env"
+    completed = subprocess.run(
+        [sys.executable, str(RUNNER), str(missing), sys.executable, "--version"],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+    assert completed.returncode != 0
+    assert "environment file does not exist" in completed.stderr

--- a/scripts/deploy/mgx-prod-01.sh
+++ b/scripts/deploy/mgx-prod-01.sh
@@ -9,10 +9,30 @@ LIVE_ORIGIN="${LIVE_ORIGIN:-https://mgx-poker.com}"
 DEFAULT_BRANCH="main"
 GIT_REMOTE="${GIT_REMOTE:-origin}"
 GIT_BRANCH="${GIT_BRANCH:-$DEFAULT_BRANCH}"
+BACKEND_ENV_FILE="${BACKEND_ENV_FILE:-/etc/mgx/mgx-backend.env}"
 
 fail() {
   echo "[mgx-deploy] ERROR: $*" >&2
   exit 1
+}
+
+run_backend_migrations() {
+  local env_file="$1"
+  local alembic_bin
+
+  if [ ! -f "$env_file" ] || [ ! -r "$env_file" ]; then
+    fail "backend environment file is not readable: ${env_file}"
+  fi
+  alembic_bin="$(command -v alembic)"
+  if [ -z "$alembic_bin" ]; then
+    fail "alembic executable is unavailable in the backend virtual environment"
+  fi
+
+  # Parse the systemd-compatible dotenv file without evaluating it as shell
+  # code. Secrets are passed only through the child process environment and
+  # are never printed or placed on the command line.
+  python "$APP_DIR/scripts/deploy/run-with-dotenv.py" \
+    "$env_file" "$alembic_bin" upgrade head
 }
 
 asset_refs_from_index() {
@@ -155,7 +175,7 @@ else
   exit 1
 fi
 echo "[mgx-deploy] applying backend database migrations"
-alembic upgrade head
+run_backend_migrations "$BACKEND_ENV_FILE"
 deactivate
 cd "$APP_DIR"
 

--- a/scripts/deploy/run-with-dotenv.py
+++ b/scripts/deploy/run-with-dotenv.py
@@ -1,0 +1,35 @@
+#!/usr/bin/env python3
+"""Run a command with values from a dotenv file without shell evaluation."""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+import sys
+
+from dotenv import dotenv_values
+
+
+def main(argv: list[str]) -> int:
+    if len(argv) < 3:
+        raise SystemExit("usage: run-with-dotenv.py ENV_FILE COMMAND [ARG ...]")
+
+    env_file = Path(argv[1])
+    if not env_file.is_file():
+        raise SystemExit(f"environment file does not exist: {env_file}")
+
+    command = argv[2:]
+    environment = os.environ.copy()
+    environment.update(
+        {
+            key: value
+            for key, value in dotenv_values(env_file).items()
+            if key and value is not None
+        }
+    )
+    os.execvpe(command[0], command, environment)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv))

--- a/scripts/deploy/test-mgx-prod-01-static.sh
+++ b/scripts/deploy/test-mgx-prod-01-static.sh
@@ -4,11 +4,21 @@ set -euo pipefail
 script="scripts/deploy/mgx-prod-01.sh"
 bash -n "$script"
 
-migration_line="$(grep -n 'alembic upgrade head' "$script" | cut -d: -f1)"
+# shellcheck disable=SC2016
+migration_line="$(grep -n 'run_backend_migrations "\$BACKEND_ENV_FILE"' "$script" | cut -d: -f1)"
 restart_line="$(grep -n 'systemctl restart mgx-backend.service' "$script" | cut -d: -f1)"
 test -n "$migration_line"
 test -n "$restart_line"
 test "$migration_line" -lt "$restart_line"
+# shellcheck disable=SC2016
+grep -q 'BACKEND_ENV_FILE="${BACKEND_ENV_FILE:-/etc/mgx/mgx-backend.env}"' "$script"
+grep -q 'scripts/deploy/run-with-dotenv.py' "$script"
+# shellcheck disable=SC2016
+grep -q '"\$env_file" "\$alembic_bin" upgrade head' "$script"
+if grep -q 'source .*BACKEND_ENV_FILE' "$script"; then
+  echo "backend environment file must not be evaluated as shell code" >&2
+  exit 1
+fi
 grep -q 'verify_live_frontend' "$script"
 grep -q 'verify_live_p2p_rest_route' "$script"
 


### PR DESCRIPTION
## Summary
- load the canonical production backend environment before Alembic runs
- parse dotenv values without shell evaluation or secret-bearing command arguments
- fail preflight when the production environment file is unreadable
- add runner behavior tests and strengthen deploy static checks

## Root cause
Manual deploy run 33128450206 updated the production checkout and built successfully, then stopped before migration/restart because Alembic did not inherit the systemd backend environment and Settings rejected the missing SECRET_KEY.

## Safety
- no secret values are printed or placed in argv
- dotenv contents are not sourced as shell code
- migration remains before frontend sync and backend restart
- failure remains fail-closed

## Verification
- backend: 68 passed
- deploy static safety: passed
- bash syntax and shellcheck: passed
- workflow YAML parse: passed
- diff check: passed

After CI and merge, rerun the manual main deployment and verify live health/P2P/telemetry.