### PR TITLE
fix(deploy): migrate with protected production environment

### DIFF
--- a/.github/workflows/deploy-mgx-prod-01.yml
+++ b/.github/workflows/deploy-mgx-prod-01.yml
@@ -128,7 +128,7 @@ jobs:
           branch="$1"
           cd /home/mgx/badugi-app
           test -z "$(git status --porcelain --untracked-files=no)"
-          test -r /etc/mgx/mgx-backend.env
+          sudo -n test -r /etc/mgx/mgx-backend.env
           git fetch origin "$branch"
           git rev-parse --verify "origin/$branch"
           sudo -n /usr/sbin/nginx -t

--- a/scripts/deploy/mgx-prod-01.sh
+++ b/scripts/deploy/mgx-prod-01.sh
@@ -19,19 +19,25 @@ fail() {
 run_backend_migrations() {
   local env_file="$1"
   local alembic_bin
+  local python_bin
 
-  if [ ! -f "$env_file" ] || [ ! -r "$env_file" ]; then
+  if ! sudo -n test -f "$env_file" || ! sudo -n test -r "$env_file"; then
     fail "backend environment file is not readable: ${env_file}"
   fi
   alembic_bin="$(command -v alembic)"
+  python_bin="$(command -v python)"
   if [ -z "$alembic_bin" ]; then
     fail "alembic executable is unavailable in the backend virtual environment"
   fi
+  if [ -z "$python_bin" ]; then
+    fail "python executable is unavailable in the backend virtual environment"
+  fi
 
   # Parse the systemd-compatible dotenv file without evaluating it as shell
-  # code. Secrets are passed only through the child process environment and
-  # are never printed or placed on the command line.
-  python "$APP_DIR/scripts/deploy/run-with-dotenv.py" \
+  # code. The production file is intentionally root-readable only, so the
+  # narrowly scoped migration child runs through non-interactive sudo. Secrets
+  # stay in that child environment and are never printed or placed on argv.
+  sudo -n -- "$python_bin" "$APP_DIR/scripts/deploy/run-with-dotenv.py" \
     "$env_file" "$alembic_bin" upgrade head
 }
 

--- a/scripts/deploy/test-mgx-prod-01-static.sh
+++ b/scripts/deploy/test-mgx-prod-01-static.sh
@@ -15,6 +15,8 @@ grep -q 'BACKEND_ENV_FILE="${BACKEND_ENV_FILE:-/etc/mgx/mgx-backend.env}"' "$scr
 grep -q 'scripts/deploy/run-with-dotenv.py' "$script"
 # shellcheck disable=SC2016
 grep -q '"\$env_file" "\$alembic_bin" upgrade head' "$script"
+# shellcheck disable=SC2016
+grep -q 'sudo -n -- "\$python_bin"' "$script"
 if grep -q 'source .*BACKEND_ENV_FILE' "$script"; then
   echo "backend environment file must not be evaluated as shell code" >&2
   exit 1


### PR DESCRIPTION
## Summary
- preflight the root-protected backend environment through non-interactive sudo
- run only the migration child with the protected dotenv environment
- keep secrets out of shell evaluation, argv, and logs

## Validation
- npm run test:deploy:static
- backend deploy runner tests (2 passed)
- shellcheck
- diff check