### PR TITLE
fix(deploy): publish stable ONNX WASM asset

### DIFF
--- a/.github/workflows/deploy-mgx-prod-01.yml
+++ b/.github/workflows/deploy-mgx-prod-01.yml
@@ -29,6 +29,7 @@ jobs:
       - run: npm ci --legacy-peer-deps
       - run: npm run lint
       - run: npm run build
+      - run: npm run test:build:onnx
       - run: npm run test:tier1
       - run: npm run test:game:progress
       - run: npm run test:game:ev

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "test:tournament:devices": "playwright test --project=tournament-android-chromium --project=tournament-iphone-webkit",
     "test:p2p": "vitest run src/ui/screens/__tests__/FriendMatchSetupScreen.test.jsx --project=tier2 && playwright test tests/e2e/p2p-friend-match-production-ws.spec.ts tests/e2e/p2p-friend-match-rest-fallback.spec.ts --project=badugi-flow",
     "test:deploy:static": "bash scripts/deploy/test-mgx-prod-01-static.sh",
+    "test:build:onnx": "node scripts/deploy/verify-built-onnx-assets.mjs",
     "test:ai-evaluation": "vitest run --project=tier3 src/ai/evaluation --silent=passed-only",
     "test:all:serial": "npm run test:tier1 -- --pool=forks --maxWorkers=1 --no-file-parallelism --silent=passed-only && npm run test:tier2 -- --pool=forks --maxWorkers=1 --no-file-parallelism --silent=passed-only && npm run test:tier3",
     "test:artifacts": "vitest run --config vitest.artifacts.config.js",

--- a/scripts/deploy/mgx-prod-01.sh
+++ b/scripts/deploy/mgx-prod-01.sh
@@ -157,6 +157,7 @@ env npm_config_cache="$NPM_CACHE_DIR" npm ci --legacy-peer-deps
 
 echo "[mgx-deploy] building frontend"
 npm run build
+npm run test:build:onnx
 
 echo "[mgx-deploy] installing backend dependencies"
 cd backend

--- a/scripts/deploy/test-mgx-prod-01-static.sh
+++ b/scripts/deploy/test-mgx-prod-01-static.sh
@@ -18,5 +18,6 @@ if grep -q 'source .*BACKEND_ENV_FILE' "$script"; then
 fi
 grep -q 'verify_live_frontend' "$script"
 grep -q 'verify_live_p2p_rest_route' "$script"
+grep -q 'npm run test:build:onnx' "$script"
 
 echo "deploy static safety: PASS"

--- a/scripts/deploy/verify-built-onnx-assets.mjs
+++ b/scripts/deploy/verify-built-onnx-assets.mjs
@@ -1,0 +1,27 @@
+import { open, stat } from "node:fs/promises";
+import path from "node:path";
+
+const expectedPath = path.resolve(
+  "dist/assets/ort-wasm-simd-threaded.jsep.wasm",
+);
+const minimumBytes = 1_000_000;
+
+const details = await stat(expectedPath).catch(() => null);
+if (!details?.isFile() || details.size < minimumBytes) {
+  throw new Error(
+    `Missing deployable ONNX WASM at ${expectedPath} (minimum ${minimumBytes} bytes)`,
+  );
+}
+
+const handle = await open(expectedPath, "r");
+try {
+  const magic = Buffer.alloc(4);
+  await handle.read(magic, 0, magic.length, 0);
+  if (!magic.equals(Buffer.from([0x00, 0x61, 0x73, 0x6d]))) {
+    throw new Error(`ONNX WASM has an invalid header: ${expectedPath}`);
+  }
+} finally {
+  await handle.close();
+}
+
+console.log(`ONNX deploy asset: PASS (${details.size} bytes)`);

--- a/vite.config.js
+++ b/vite.config.js
@@ -46,6 +46,14 @@ export default defineConfig(({ command }) => {
       chunkSizeWarningLimit: 600,
       rollupOptions: {
         output: {
+          // onnxruntime-web resolves its worker WASM by this stable basename at
+          // runtime. A content hash makes the generated JS request a missing
+          // path, which nginx then turns into the SPA HTML fallback.
+          assetFileNames(assetInfo) {
+            const originalName = assetInfo.names?.[0] ?? assetInfo.name ?? "";
+            if (originalName.endsWith(".wasm")) return "assets/[name][extname]";
+            return "assets/[name]-[hash][extname]";
+          },
           manualChunks(id) {
             if (id.includes("node_modules")) {
               if (id.includes("onnxruntime-web")) return "onnx-runtime";


### PR DESCRIPTION
## Summary
- preserve the ONNX worker WASM basename expected by onnxruntime-web
- validate the built artifact is present, large enough, and has a WebAssembly header
- gate both CI and production deployment on that artifact check

## Production finding
The deployed hashed WASM was not discoverable by onnxruntime-web; `/assets/ort-wasm-simd-threaded.jsep.wasm` returned SPA HTML and Core5 live smoke reported WASM compile/fetch aborts.

## Validation
- production build PASS
- ONNX artifact check PASS (23,824,254 bytes)
- preview serves `application/wasm`
- bundle references the stable basename
- deploy static safety, lint, diff check PASS