### PR TITLE
fix(tournament): guard actions with canonical actor

### DIFF
--- a/src/ui/App.jsx
+++ b/src/ui/App.jsx
@@ -4103,8 +4103,16 @@ export default function App() {
               ? (...args) => console.warn(...args)
               : undefined,
         });
+    // Tournament rebalancing can update the canonical/controller actor before
+    // the legacy `turn` state catches up. Controls are rendered from
+    // `controllerTurn`, so the click guard must use that same source or a
+    // visible Hero DRAW button can be rejected forever on a later hand.
     const expectedTurn =
-      typeof controllerActionSeat === "number" ? controllerActionSeat : turn;
+      isTableActionPhase && typeof controllerTurn === "number"
+        ? controllerTurn
+        : typeof controllerActionSeat === "number"
+          ? controllerActionSeat
+          : turn;
     if (expectedTurn !== seat) {
       logE2EError("turn mismatch before action", {
         seat,

--- a/tests/e2e/p2p-friend-match-production-ws.spec.ts
+++ b/tests/e2e/p2p-friend-match-production-ws.spec.ts
@@ -191,6 +191,25 @@ async function waitForEnabledPage(
   throw new Error(`${testId} did not become enabled for either player`);
 }
 
+async function waitForEnabledAction(
+  candidates: Array<{ label: string; page: Page }>,
+  testIds: string[],
+  timeoutMs = 15_000,
+) {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    for (const candidate of candidates) {
+      for (const testId of testIds) {
+        if (await candidate.page.locator(`[data-testid="${testId}"]:not([disabled])`).count()) {
+          return { ...candidate, testId };
+        }
+      }
+    }
+    await new Promise((resolve) => setTimeout(resolve, 100));
+  }
+  throw new Error(`No P2P player received an enabled action: ${testIds.join(", ")}`);
+}
+
 test.beforeAll(async () => {
   if (await backendIsHealthy()) return;
   backendProcess = spawn(
@@ -280,9 +299,17 @@ test.describe("production P2P friend match websocket", () => {
       await expect(guest.getByTestId(`p2p-player-${guestSession.user.id}`)).toBeVisible();
 
       await expectNoHorizontalOverflow(host);
-      const opener = await clickFirstEnabled(host, ["p2p-call", "p2p-check"]);
-      expect(opener).toBe("p2p-call");
-      await clickFirstEnabled(guest, ["p2p-check", "p2p-call"]);
+      const opener = await waitForEnabledAction(
+        [
+          { label: "host", page: host },
+          { label: "guest", page: guest },
+        ],
+        ["p2p-call", "p2p-check"],
+      );
+      expect(opener.testId).toBe("p2p-call");
+      await opener.page.getByTestId(opener.testId).click();
+      const responder = opener.label === "host" ? guest : host;
+      await clickFirstEnabled(responder, ["p2p-check", "p2p-call"]);
 
       const firstDrawer = await waitForEnabledPage(
         [

--- a/tests/e2e/p2p-friend-match-production-ws.spec.ts
+++ b/tests/e2e/p2p-friend-match-production-ws.spec.ts
@@ -309,7 +309,11 @@ test.describe("production P2P friend match websocket", () => {
       expect(opener.testId).toBe("p2p-call");
       await opener.page.getByTestId(opener.testId).click();
       const responder = opener.label === "host" ? guest : host;
-      await clickFirstEnabled(responder, ["p2p-check", "p2p-call"]);
+      const response = await waitForEnabledAction(
+        [{ label: opener.label === "host" ? "guest" : "host", page: responder }],
+        ["p2p-check", "p2p-call"],
+      );
+      await response.page.getByTestId(response.testId).click();
 
       const firstDrawer = await waitForEnabledPage(
         [


### PR DESCRIPTION
## Summary
- use the same canonical actor for visible tournament controls and click authorization
- prevent a stale legacy turn after rebalancing from rejecting a valid Hero DRAW forever

## CI reproduction
Store froze on hand 36 in DRAW with visible `action-draw-selected`, canonical actor 0, and stale internal action guard.

## Validation
- Store production field to champion: 3/3 consecutive PASS (33-53 real Hero hands, 40-58 background hands)
- actor source tests 69/69 PASS
- build + ONNX deploy asset PASS
- focused eslint and diff check PASS