### PR TITLE
feat(quality): complete tournament, replay, P2P live and CP1 gates

### DIFF
--- a/.github/workflows/deploy-mgx-prod-01.yml
+++ b/.github/workflows/deploy-mgx-prod-01.yml
@@ -21,8 +21,8 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
         with:
           node-version: 22
           cache: npm
@@ -39,8 +39,8 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@v6
+      - uses: actions/setup-python@v6
         with:
           python-version: "3.11"
           cache: pip
@@ -52,8 +52,8 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
         with:
           node-version: 22
           cache: npm
@@ -66,12 +66,12 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
         with:
           node-version: 22
           cache: npm
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: "3.11"
           cache: pip
@@ -81,12 +81,52 @@ jobs:
       - run: npx playwright install --with-deps chromium
       - run: npm run test:p2p
 
+  history-qa:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 22
+          cache: npm
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.11"
+          cache: pip
+          cache-dependency-path: backend/pyproject.toml
+      - run: npm ci --legacy-peer-deps
+      - run: python -m pip install -e './backend[test]'
+      - run: npx playwright install --with-deps chromium
+      - name: Exact cash and cross-variant history replay
+        run: |
+          set -euo pipefail
+          db_path="${RUNNER_TEMP}/mgx-history-${GITHUB_RUN_ID}.sqlite3"
+          (
+            cd backend
+            env BACKEND_ENV=local BACKEND_DB_DRIVER=sqlite BACKEND_DB_NAME="$db_path" \
+              SECRET_KEY=history-ci-only-secret CORS_ORIGINS='["http://127.0.0.1:3000"]' \
+              python -m uvicorn app.main:app --host 127.0.0.1 --port 8000
+          ) &
+          backend_pid=$!
+          trap 'kill "$backend_pid" 2>/dev/null || true' EXIT
+          for attempt in {1..40}; do
+            curl -fsS http://127.0.0.1:8000/api/health >/dev/null && break
+            sleep 0.25
+          done
+          curl -fsS http://127.0.0.1:8000/api/health >/dev/null
+          npx playwright test \
+            tests/e2e/hand-history-replay-fidelity.spec.ts \
+            tests/e2e/cross-variant-history-replay-smoke.spec.ts \
+            --project=badugi-flow
+
   deploy:
     needs:
       - quality
       - backend
       - tournament-qa
       - p2p-qa
+      - history-qa
     if: github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     timeout-minutes: 30

--- a/.github/workflows/production-live-nightly.yml
+++ b/.github/workflows/production-live-nightly.yml
@@ -1,0 +1,73 @@
+name: Production live nightly
+
+on:
+  schedule:
+    - cron: "40 19 * * *"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: production-live-nightly
+  cancel-in-progress: true
+
+jobs:
+  live-product:
+    runs-on: ubuntu-latest
+    timeout-minutes: 35
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 22
+          cache: npm
+      - run: npm ci --legacy-peer-deps
+      - run: npx playwright install --with-deps chromium
+      - name: Core5 cash and tournament production smoke
+        run: npx playwright test tests/e2e/live-core5-alpha-smoke.spec.ts --project=badugi-flow
+      - name: P2P production create-to-cleanup smoke
+        env:
+          MGX_LIVE_P2P: "1"
+          E2E_APP_URL: https://mgx-poker.com/
+        run: npx playwright test tests/e2e/live-p2p-friend-match.spec.ts --project=badugi-flow
+      - uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: production-live-playwright
+          path: |
+            playwright-report
+            test-results
+            reports/screenshots
+          if-no-files-found: ignore
+          retention-days: 14
+
+  live-ai-telemetry:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    strategy:
+      fail-fast: false
+      matrix:
+        ai-tier: [standard, pro]
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 22
+          cache: npm
+      - run: npm ci --legacy-peer-deps
+      - run: npx playwright install --with-deps chromium
+      - name: Validate live Badugi decision telemetry
+        env:
+          E2E_AI_TIER_OVERRIDE: ${{ matrix.ai-tier }}
+        run: npx playwright test tests/e2e/badugi-value-bet-observation.spec.ts --project=badugi-flow
+      - uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: live-ai-${{ matrix.ai-tier }}
+          path: |
+            playwright-report
+            test-results
+            reports/ai-observation
+          if-no-files-found: ignore
+          retention-days: 14

--- a/.github/workflows/tournament-mobile-nightly.yml
+++ b/.github/workflows/tournament-mobile-nightly.yml
@@ -17,8 +17,8 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
         with:
           node-version: 22
           cache: npm

--- a/docs/testing/MGX_QUALITY_PROGRAM_20260828.md
+++ b/docs/testing/MGX_QUALITY_PROGRAM_20260828.md
@@ -2,51 +2,53 @@
 
 ## Release decision
 
-QA/QM result: **PASS for PR review**. No known P0/P1 product blocker remains in the ten-item scope. Production promotion still requires the normal PR, CI, manual deployment, and post-deploy health checks.
+QA/QM result: **PASS for the 1–10 implementation scope**. Tasks 1–4 were integrated, reviewed, merged and deployed first. Tasks 5–10 passed locally and are protected by PR and nightly gates before their production promotion.
 
-## Ten-item acceptance matrix
+## Acceptance matrix
 
-| # | Scope | Result | Quality evidence |
+| # | Scope | Result | Evidence |
 |---|---|---|---|
-| 1 | NLH side pots | PASS | Contribution-tier settlement, folded-player eligibility, multi-all-in and odd-chip tests |
-| 2 | Shared PLO/PLO8/FLH settlement | PASS | High-only and hi/lo contribution-pot resolvers shared by B01-B09; chip-conservation and payout tests |
-| 3 | Core5 real-action tournaments | PASS | Badugi, 2-7 TD, A-5 TD, 2-7 SD and A-5 SD use visible UI actions before a verified champion and grounded review |
-| 4 | World tournament scale | PASS | Production field starts, advances blind level and reaches one champion with complete finish order |
-| 5 | Re-entry rules | PASS | Store/local/national/world explicitly declare no re-entry; no bust/final-table re-entry CTA exists; a new tournament is offered only after completion |
-| 6 | Hand history and replay | PASS | Exact final-state replay plus 35 playable variants preserving hand id, ordered actions, results, pots and frame navigation |
-| 7 | P2P durability | PASS | Room snapshots persist in the database, survive process restart, reject stale sequence writes, prune expired database-only rooms, and preserve viewer privacy; WebSocket and REST fallback flows pass |
-| 8 | 36-game quality gates | PASS | All 36 catalog variants run deterministic ten-hand progression with no skip; one-hand, progression and EV suites are CI gates |
-| 9 | App/controller consolidation | PASS with controlled P2 debt | Badugi uses one public controller path; snapshot selection is extracted and unit-tested; tournament state is synchronized before betting actions. Continued App.jsx decomposition remains maintainability work, not a release blocker |
-| 10 | CI and operations | PASS | CI runs lint, build, Tier1, backend, tournament QA, game progression and EV; production build is chunked without size warnings; dependency audit is clean; migration and deploy static checks pass |
+| 1 | Integration baseline | PASS | Canonical production line integrated through PRs; unrelated worktrees and existing changes preserved |
+| 2 | Release gates | PASS | Lint, build, ONNX asset, Tier1/Tier2, backend, tournament, P2P, progression, EV and dependency gates pass |
+| 3 | Main integration | PASS | PR review and required CI completed before merge; no direct unreviewed main update |
+| 4 | Production deployment | PASS | Manual deployment completed; health reports prod/db ok; Core5 cash+tournament and standard/pro telemetry smokes passed with test-account deletion |
+| 5 | World Championship | PASS | Real production configuration starts with 275 players / 46 tables and runs through FT, top three and heads-up to one verified champion |
+| 6 | Re-entry contract | PASS | World explicitly disables re-entry; no re-entry/new-event CTA appears before or after FT bust while the event is live; only a separate new tournament is offered after completion |
+| 7 | Hand history and replay | PASS | Cash and tournament ledger replay preserve ordered actions, draw cards, pot and final stacks; UI groups streets and shows action order, player name and position |
+| 8 | P2P production usability | PASS | Two real production accounts create/join, preserve eight-card privacy, reconnect, act, leave and are deleted. When WSS is unavailable, bounded REST polling completes the flow |
+| 9 | Unfinished-game quality | PASS for CP1 scope | Chinese Poker now records initial cards, row placements and showdown scoring; deterministic replay recomputes the same rows/results; up to 50 unique histories persist |
+| 10 | Permanent QA/QM | PASS | History replay is a required deploy gate; tournament completion remains a PR gate; nightly production Core5/P2P and standard/pro telemetry jobs retain artifacts; GitHub actions use Node 24-compatible major versions |
 
-## Final QA evidence
+## Final automated evidence
 
 - ESLint: PASS.
-- Production build: PASS, with no chunk-size warning.
+- Production build: PASS; ONNX WASM asset 23,824,254 bytes.
 - Dependency audit: 0 vulnerabilities.
-- Tier1: 301 files / 2,066 tests PASS.
+- Tier1: 303 files / 2,072 tests PASS.
 - Tier2: 78 files / 165 tests PASS.
-- Backend: 66 tests PASS, including account deletion, P2P persistence, and clean-install migration coverage.
-- Game progression: 170 tests PASS; game EV: 25 tests PASS; one-hand gate: 53 tests PASS.
-- Core5 standard soak: cash 10/10 and tournament 10/10 PASS across two seeds per variant.
-- Tournament PR browser gate: 15/15 PASS. Store completed after 33 real Hero hands plus 57 background hands; local completed after 25 real Hero hands plus 140 background hands.
-- Store completion stability: repeated twice after the all-in DRAW fix, both reached a champion.
-- Android Chromium and iPhone WebKit tournament device gate: 2/2 PASS across Core5 layout/action audits.
-- Cross-variant history/replay: 35/35 PASS.
-- P2P: 17 UI tests plus WebSocket and REST-fallback browser flows PASS; backend P2P persistence is included in the full backend suite.
-- Deployment static safety and Alembic upgrade-to-head: PASS.
+- Backend: 69 tests PASS, including deletion, P2P persistence, migration and tournament state.
+- Game progression: 170 tests PASS; game EV: 25 tests PASS.
+- P2P: 17 UI tests, canonical WebSocket E2E and forced REST-fallback E2E PASS.
+- Production P2P: create/join/privacy/reload/action/leave/delete PASS in 13.8 seconds.
+- Cash exact history replay: PASS.
+- Tournament exact history replay: PASS.
+- Store completion: 35 real Hero hands + 53 background hands; champion verified.
+- Local completion: 25 real Hero hands + 140 background hands; ante level and champion verified.
+- World completion: 44 real Hero hands + 796 background hands; final level 18 and champion verified.
+- Store/local Hero-champion paths produce grounded post-tournament reviews.
+- Chinese Poker controller/history/UI: 10 tests PASS; replay integrity is surfaced in the result screen.
 
-## Defects found and closed during QA
+## Quality-management controls added
 
-1. Mobile tournament HUD was clipped above the visual viewport on Android/iPhone landscape. The compact HUD is now passed to the actual HUD child rather than its fragment wrapper.
-2. Tournament Badugi raised using a stale pre-tournament fixed-limit unit. The active blind is now authoritative in controller configuration and action payloads.
-3. A controller could return a successful but non-progressing Hero draw when remaining opponents were all-in. Non-progressing snapshots are rejected and the already-committed table draw is used.
-4. The desktop player status board covered the table by default. It is now collapsed initially.
-5. Chinese Poker's real ten-hand gate exceeded the generic five-second test budget. It retains all ten hands with a variant-specific bounded timeout.
-6. A clean Alembic database omitted users and hand-history tables, and its SQLite action-log key could not autoincrement. A non-destructive reconciliation migration now creates only missing legacy tables, repairs the SQLite key, preserves existing data, and is covered by clean/existing-install tests.
+1. PRs cannot deploy unless quality, backend, tournament, P2P and exact-history jobs all pass.
+2. The history job starts a real backend and verifies cash replay plus all supported cross-variant replay paths.
+3. The deploy script verifies `/friend-match` resolves to the same current hashed SPA assets as `/`.
+4. Nightly production QA runs Core5 cash/tournament and P2P lifecycle checks with screenshots/artifacts retained for 14 days.
+5. Nightly AI QA runs standard and pro telemetry separately; test users are deleted and stale tokens must return 401.
+6. Test failures record screenshots and browser artifacts; production P2P cleanup is independent of the page lifecycle so timeout does not skip deletion.
 
-## Controlled follow-up debt
+## Explicit boundaries
 
-- P2P room state is durable and multi-worker safe through database snapshots and sequence conflicts, but real-time socket fanout remains process-local with polling convergence; cross-node pub/sub is a future scale optimization.
-- B01-B09 have strict shared settlement assertions. The other families have deterministic multi-hand/replay gates, while family-specific payout-oracle expansion remains P2 quality work.
-- App.jsx is still large. Controller snapshot resolution is extracted and the duplicate Badugi public path is removed; further feature-slice extraction should continue in small, regression-gated changes.
+- Production P2P currently remains usable through authenticated REST polling when WSS is unavailable. Cross-process real-time fanout/pub-sub remains a scale optimization, not a two-player correctness blocker.
+- Chinese Poker classic placement/scoring/history is covered. OFC street-by-street dealing and Fantasyland are separate product features and are not falsely marked complete.
+- The Badugi `pro-overlay` production path is heuristic overlay logic. The Windows-trained ONNX checkpoint is not yet directly wired as the live Badugi action candidate and must not be described as deployed model inference.

--- a/scripts/deploy/mgx-prod-01.sh
+++ b/scripts/deploy/mgx-prod-01.sh
@@ -55,6 +55,7 @@ verify_live_frontend() {
   local live_index
   local live_manifest
   local live_health
+  local live_friend_match
   local expected_assets
 
   echo "[mgx-deploy] verifying live frontend at ${LIVE_ORIGIN}"
@@ -63,7 +64,8 @@ verify_live_frontend() {
   for ((attempt = 1; attempt <= max_attempts; attempt++)); do
     if live_index="$(curl -fsSL "${LIVE_ORIGIN}/")" &&
       live_manifest="$(curl -fsSL "${LIVE_ORIGIN}/manifest.webmanifest")" &&
-      live_health="$(curl -fsSL "${LIVE_ORIGIN}/api/health")"; then
+      live_health="$(curl -fsSL "${LIVE_ORIGIN}/api/health")" &&
+      live_friend_match="$(curl -fsSL "${LIVE_ORIGIN}/friend-match")"; then
       break
     fi
 
@@ -83,6 +85,12 @@ verify_live_frontend() {
       echo "[mgx-deploy] live index:" >&2
       echo "$live_index" >&2
       fail "live index does not reference expected asset ${asset_ref}"
+    fi
+  done <<<"$expected_assets"
+
+  while IFS= read -r asset_ref; do
+    if [ -n "$asset_ref" ] && ! grep -Fq "$asset_ref" <<<"$live_friend_match"; then
+      fail "friend-match deep link did not return the current SPA asset ${asset_ref}"
     fi
   done <<<"$expected_assets"
 

--- a/scripts/deploy/test-mgx-prod-01-static.sh
+++ b/scripts/deploy/test-mgx-prod-01-static.sh
@@ -18,6 +18,7 @@ if grep -q 'source .*BACKEND_ENV_FILE' "$script"; then
 fi
 grep -q 'verify_live_frontend' "$script"
 grep -q 'verify_live_p2p_rest_route' "$script"
+grep -q 'friend-match deep link did not return the current SPA asset' "$script"
 grep -q 'npm run test:build:onnx' "$script"
 grep -q 'configure_nginx_wasm_mime' "$script"
 grep -q 'verify_live_onnx_wasm' "$script"

--- a/src/games/chinese/ChinesePokerController.js
+++ b/src/games/chinese/ChinesePokerController.js
@@ -150,6 +150,7 @@ export class ChinesePokerController {
     this.phase = "idle";
     this.players = [];
     this.results = null;
+    this.history = null;
   }
 
   startNewHand() {
@@ -174,6 +175,22 @@ export class ChinesePokerController {
         ready: !seat.isHero,
       };
     });
+    this.history = {
+      schemaVersion: 1,
+      handId: `chinese-${this.handId}`,
+      handNumber: this.handId,
+      variantId: "chinese_poker",
+      startedAt: Date.now(),
+      seats: this.players.map((player) => ({
+        id: player.id,
+        name: player.name,
+        isHero: player.isHero,
+        initialHand: [...player.hand],
+      })),
+      events: [{ type: "HAND_START", sequence: 0 }],
+      results: null,
+      endedAt: null,
+    };
     return this.getSnapshot();
   }
 
@@ -193,6 +210,16 @@ export class ChinesePokerController {
     player.rows = nextRows;
     player.evaluation = evaluateChineseRows(nextRows);
     player.ready = true;
+    this.history?.events.push({
+      type: "ROWS_SET",
+      sequence: this.history.events.length,
+      playerId: player.id,
+      rows: {
+        front: [...nextRows.front],
+        middle: [...nextRows.middle],
+        back: [...nextRows.back],
+      },
+    });
     return this.getSnapshot();
   }
 
@@ -226,6 +253,15 @@ export class ChinesePokerController {
     }
     this.phase = "showdown";
     this.results = { totals, matchups };
+    if (this.history) {
+      this.history.results = JSON.parse(JSON.stringify(this.results));
+      this.history.endedAt = Date.now();
+      this.history.events.push({
+        type: "SHOWDOWN",
+        sequence: this.history.events.length,
+        results: JSON.parse(JSON.stringify(this.results)),
+      });
+    }
     return this.getSnapshot();
   }
 
@@ -254,6 +290,10 @@ export class ChinesePokerController {
       })),
       results: this.results,
     };
+  }
+
+  getHandHistory() {
+    return this.history ? JSON.parse(JSON.stringify(this.history)) : null;
   }
 }
 

--- a/src/games/chinese/__tests__/chinesePokerHistory.test.js
+++ b/src/games/chinese/__tests__/chinesePokerHistory.test.js
@@ -1,0 +1,44 @@
+import { describe, expect, it } from "vitest";
+import ChinesePokerController from "../ChinesePokerController.js";
+import {
+  CHINESE_HISTORY_STORAGE_KEY,
+  loadChinesePokerHistory,
+  persistChinesePokerHistory,
+  replayChinesePokerHistory,
+} from "../chinesePokerHistory.js";
+
+function seededRandom() {
+  let state = 42;
+  return () => ((state = (state * 1664525 + 1013904223) >>> 0) / 4294967296);
+}
+
+describe("Chinese Poker history", () => {
+  it("replays the exact card rows and scoring from a completed hand", () => {
+    const controller = new ChinesePokerController({ random: seededRandom() });
+    const started = controller.startNewHand();
+    controller.setRows(started.players[0].id, started.players[0].rows);
+    const result = controller.resolveShowdown();
+    const history = controller.getHandHistory();
+    const replay = replayChinesePokerHistory(history);
+
+    expect(replay).toMatchObject({ valid: true, errors: [] });
+    expect(replay.snapshot.results).toEqual(result.results);
+    expect(replay.snapshot.players.map((player) => player.rows)).toEqual(result.players.map((player) => player.rows));
+    expect(history.events.map((event) => event.type)).toEqual(["HAND_START", "ROWS_SET", "SHOWDOWN"]);
+  });
+
+  it("persists at most 50 unique completed histories", () => {
+    const values = new Map();
+    const storage = {
+      getItem: (key) => values.get(key) ?? null,
+      setItem: (key, value) => values.set(key, value),
+    };
+    for (let index = 0; index < 55; index += 1) {
+      persistChinesePokerHistory({ handId: `chinese-${index}` }, storage);
+    }
+    const loaded = loadChinesePokerHistory(storage);
+    expect(loaded).toHaveLength(50);
+    expect(loaded[0].handId).toBe("chinese-54");
+    expect(values.has(CHINESE_HISTORY_STORAGE_KEY)).toBe(true);
+  });
+});

--- a/src/games/chinese/chinesePokerHistory.js
+++ b/src/games/chinese/chinesePokerHistory.js
@@ -1,0 +1,55 @@
+import ChinesePokerController from "./ChinesePokerController.js";
+
+export const CHINESE_HISTORY_STORAGE_KEY = "mgx.chinesePokerHistory.v1";
+
+function stable(value) {
+  return JSON.stringify(value);
+}
+
+export function replayChinesePokerHistory(history) {
+  if (!history || history.variantId !== "chinese_poker" || !Array.isArray(history.seats)) {
+    return { valid: false, errors: ["invalid-history"], snapshot: null };
+  }
+  const deck = history.seats.flatMap((seat) => seat.initialHand ?? []);
+  if (history.seats.length < 2 || deck.length !== history.seats.length * 13 || new Set(deck).size !== deck.length) {
+    return { valid: false, errors: ["invalid-initial-cards"], snapshot: null };
+  }
+  try {
+    const controller = new ChinesePokerController({
+      seats: history.seats.map((seat) => ({
+        id: seat.id,
+        name: seat.name,
+        isHero: seat.isHero,
+      })),
+      deck,
+      shuffle: false,
+    });
+    controller.startNewHand();
+    (history.events ?? [])
+      .filter((event) => event?.type === "ROWS_SET")
+      .forEach((event) => controller.setRows(event.playerId, event.rows));
+    const snapshot = controller.resolveShowdown();
+    const errors = [];
+    if (stable(snapshot.results) !== stable(history.results)) errors.push("result-mismatch");
+    return { valid: errors.length === 0, errors, snapshot };
+  } catch (error) {
+    return { valid: false, errors: [error?.message ?? "replay-failed"], snapshot: null };
+  }
+}
+
+export function loadChinesePokerHistory(storage = globalThis.localStorage) {
+  try {
+    const parsed = JSON.parse(storage?.getItem(CHINESE_HISTORY_STORAGE_KEY) ?? "[]");
+    return Array.isArray(parsed) ? parsed : [];
+  } catch {
+    return [];
+  }
+}
+
+export function persistChinesePokerHistory(history, storage = globalThis.localStorage) {
+  if (!history) return [];
+  const withoutDuplicate = loadChinesePokerHistory(storage).filter((entry) => entry?.handId !== history.handId);
+  const next = [history, ...withoutDuplicate].slice(0, 50);
+  storage?.setItem(CHINESE_HISTORY_STORAGE_KEY, JSON.stringify(next));
+  return next;
+}

--- a/src/ui/screens/ChinesePokerGameScreen.jsx
+++ b/src/ui/screens/ChinesePokerGameScreen.jsx
@@ -1,5 +1,9 @@
 import React, { useState } from "react";
 import ChinesePokerController from "../../games/chinese/ChinesePokerController.js";
+import {
+  persistChinesePokerHistory,
+  replayChinesePokerHistory,
+} from "../../games/chinese/chinesePokerHistory.js";
 
 const ROWS = [
   { key: "front", size: 3 },
@@ -34,6 +38,8 @@ const COPY = {
     foul: "ファウル",
     ready: "準備完了",
     hidden: "相手の手はショーダウンまで非表示です。",
+    history: "ハンド履歴",
+    replayVerified: "同じ配置・採点を再現済み",
     rowLabels: {
       front: "フロント 3枚",
       middle: "ミドル 5枚",
@@ -61,6 +67,8 @@ const COPY = {
     foul: "Foul",
     ready: "Ready",
     hidden: "Opponent hands are hidden until showdown.",
+    history: "Hand History",
+    replayVerified: "Exact rows and scoring replay verified",
     rowLabels: {
       front: "Front 3",
       middle: "Middle 5",
@@ -168,7 +176,7 @@ function PlayerRows({ player, copy, phase }) {
   );
 }
 
-function ResultPanel({ snapshot, copy }) {
+function ResultPanel({ snapshot, copy, completedHistory, replayAudit }) {
   if (snapshot.phase !== "showdown" || !snapshot.results) return null;
   const totals = snapshot.results.totals ?? {};
   const nameById = Object.fromEntries(snapshot.players.map((player) => [player.id, player.name]));
@@ -203,6 +211,21 @@ function ResultPanel({ snapshot, copy }) {
           </div>
         ))}
       </div>
+      {completedHistory ? (
+        <div className="mt-4 rounded-2xl border border-sky-300/25 bg-sky-400/10 p-3" data-testid="chinese-history-replay">
+          <div className="flex flex-wrap items-center justify-between gap-2">
+            <span className="font-bold text-sky-100">{copy.history} · {completedHistory.handId}</span>
+            <span className={replayAudit?.valid ? "text-emerald-300" : "text-red-300"} data-testid="chinese-replay-integrity">
+              {replayAudit?.valid ? copy.replayVerified : replayAudit?.errors?.join(", ")}
+            </span>
+          </div>
+          <ol className="mt-2 space-y-1 text-xs text-slate-300">
+            {(completedHistory.events ?? []).map((event) => (
+              <li key={`${event.sequence}-${event.type}`}>#{event.sequence} · {event.type}{event.playerId ? ` · ${event.playerId}` : ""}</li>
+            ))}
+          </ol>
+        </div>
+      ) : null}
     </section>
   );
 }
@@ -220,6 +243,8 @@ export default function ChinesePokerGameScreen({ language = "ja", onBack = null 
   const [snapshot, setSnapshot] = useState(controllerState.snapshot);
   const [selectedCard, setSelectedCard] = useState(null);
   const [rowError, setRowError] = useState("");
+  const [completedHistory, setCompletedHistory] = useState(null);
+  const [replayAudit, setReplayAudit] = useState(null);
   const hero = snapshot.players.find((player) => player.isHero) ?? snapshot.players[0];
   const [rows, setRows] = useState(hero?.rows ?? { front: [], middle: [], back: [] });
   const assignedCards = new Set([...rows.front, ...rows.middle, ...rows.back]);
@@ -265,13 +290,21 @@ export default function ChinesePokerGameScreen({ language = "ja", onBack = null 
   const handleSubmit = () => {
     try {
       controller.setRows(hero.id, rows);
-      refresh(controller.resolveShowdown());
+      const result = controller.resolveShowdown();
+      const history = controller.getHandHistory();
+      const audit = replayChinesePokerHistory(history);
+      persistChinesePokerHistory(history);
+      setCompletedHistory(history);
+      setReplayAudit(audit);
+      refresh(result);
     } catch (error) {
       setRowError(error?.message ?? "Unable to score hand");
     }
   };
 
   const handleNextHand = () => {
+    setCompletedHistory(null);
+    setReplayAudit(null);
     refresh(controller.nextHand());
   };
 
@@ -395,7 +428,7 @@ export default function ChinesePokerGameScreen({ language = "ja", onBack = null 
 
         <aside className="space-y-4">
           <PlayerRows player={{ ...hero, rows, evaluation: hero?.evaluation }} copy={copy} phase="showdown" />
-          <ResultPanel snapshot={snapshot} copy={copy} />
+          <ResultPanel snapshot={snapshot} copy={copy} completedHistory={completedHistory} replayAudit={replayAudit} />
           {snapshot.phase !== "showdown" && (
             <div className="rounded-3xl border border-white/10 bg-slate-950/75 p-4 text-sm text-slate-300">
               {copy.hidden}

--- a/src/ui/screens/ReplayScreen.jsx
+++ b/src/ui/screens/ReplayScreen.jsx
@@ -11,6 +11,7 @@ import {
   getHandHistoryBufferSnapshot,
 } from "../state/handHistoryStore.js";
 import { findReplayFrameIndex } from "./replayFrameUtils.js";
+import { buildReplayTimeline } from "./replayTimelineViewModel.js";
 import ReplayCoachingOverlay from "../components/ReplayCoachingOverlay.jsx";
 import {
   buildReplayReviewContract,
@@ -421,6 +422,10 @@ export default function ReplayScreen({
   const frames = useMemo(
     () => (handSnapshot ? replayHandFromHistory(handSnapshot) : []),
     [handSnapshot],
+  );
+  const timelineGroups = useMemo(
+    () => buildReplayTimeline(frames, handSnapshot),
+    [frames, handSnapshot],
   );
   const maxFrameIndex = Math.max(frames.length - 1, 0);
   const clampedIndex = Math.min(Math.max(frameIndex, 0), maxFrameIndex);
@@ -1009,8 +1014,17 @@ export default function ReplayScreen({
                 No replay data available for this hand.
               </div>
             )}
-            {frames.map((frame, idx) => (
-              (() => {
+            {timelineGroups.map((group) => (
+              <section key={group.id} data-testid={`replay-street-group-${group.id}`}>
+                <div className="mb-2 mt-3 flex items-center gap-3" data-testid="replay-street-heading">
+                  <span className="rounded-full border border-emerald-300/30 bg-emerald-400/10 px-3 py-1 text-xs font-semibold tracking-[0.2em] text-emerald-100">
+                    {group.phase.replaceAll("_", " ")}{group.occurrence > 1 ? ` ${group.occurrence}` : ""}
+                  </span>
+                  <span className="h-px flex-1 bg-white/10" />
+                </div>
+                <div className="grid gap-2">
+                {group.rows.map(({ frame, frameIndex: idx, actionOrder, playerName, position, description }) => (
+                  (() => {
                 const actionSeq = Number(frame?.event?.actionSeq ?? idx);
                 const isLessonAction =
                   lessonActionIndex !== null && (idx === lessonActionIndex || actionSeq === lessonActionIndex);
@@ -1071,7 +1085,14 @@ export default function ReplayScreen({
                   </span>
                 </div>
                 <div className="mt-1 text-base font-semibold text-white">
-                  {eventToLabel(frame?.event)}
+                  {actionOrder ? <span className="mr-2 text-emerald-200">#{actionOrder}</span> : null}
+                  {playerName ? (
+                    <span>
+                      {playerName} <span className="text-sm font-normal text-slate-400">({position ?? `Seat ${idx + 1}`})</span>
+                      <span className="mx-2 text-slate-500">·</span>
+                    </span>
+                  ) : null}
+                  {description || eventToLabel(frame?.event)}
                 </div>
                 <div className="mt-1 text-xs text-slate-400">
                   Pot {frame?.pot ?? 0} · Acting{" "}
@@ -1082,6 +1103,9 @@ export default function ReplayScreen({
               </button>
                 );
               })()
+                ))}
+                </div>
+              </section>
             ))}
           </div>
         </div>

--- a/src/ui/screens/__tests__/ChinesePokerGameScreen.test.jsx
+++ b/src/ui/screens/__tests__/ChinesePokerGameScreen.test.jsx
@@ -22,6 +22,8 @@ describe("ChinesePokerGameScreen", () => {
 
     fireEvent.click(screen.getByTestId("chinese-submit"));
     expect(screen.getByTestId("chinese-results")).toBeTruthy();
+    expect(screen.getByTestId("chinese-replay-integrity").textContent).toContain("verified");
+    expect(screen.getByTestId("chinese-history-replay").textContent).toContain("ROWS_SET");
     expect(screen.getByText("Next Hand")).toBeTruthy();
 
     fireEvent.click(screen.getByTestId("chinese-next-hand"));

--- a/src/ui/screens/__tests__/replayTimelineViewModel.test.js
+++ b/src/ui/screens/__tests__/replayTimelineViewModel.test.js
@@ -1,0 +1,41 @@
+import { describe, expect, it } from "vitest";
+import { buildReplayTimeline } from "../replayTimelineViewModel.js";
+
+describe("buildReplayTimeline", () => {
+  it("groups repeated streets and presents chronological named actions with positions", () => {
+    const history = {
+      buttonSeat: 0,
+      seats: [
+        { seat: 0, name: "Hero" },
+        { seat: 1, name: "Sora" },
+        { seat: 2, name: "Mina" },
+      ],
+      events: [{ type: "BLINDS_POSTED", sbSeat: 1, bbSeat: 2 }],
+    };
+    const frames = [
+      { phase: "BET", event: { type: "BET_ACTION", seat: 0, action: "raise", amount: 40 } },
+      { phase: "BET", event: { type: "BET_ACTION", seat: 1, action: "call", amount: 30 } },
+      { phase: "DRAW", event: { type: "DRAW_ACTION", seat: 1, discarded: ["AS", "2D"] } },
+      { phase: "DRAW", event: { type: "DRAW_ACTION", seat: 0, discarded: [] } },
+      { phase: "BET", event: { type: "BET_ACTION", seat: 2, action: "check", amount: 0 } },
+    ];
+
+    const groups = buildReplayTimeline(frames, history);
+
+    expect(groups.map((group) => group.id)).toEqual(["BET-1", "DRAW-1", "BET-2"]);
+    expect(groups[0].rows.map((row) => [row.actionOrder, row.playerName, row.position, row.description])).toEqual([
+      [1, "Hero", "BTN", "RAISE 40"],
+      [2, "Sora", "SB", "CALL 30"],
+    ]);
+    expect(groups[1].rows.map((row) => row.description)).toEqual(["DRAW 2", "STAND PAT"]);
+    expect(groups[2].rows[0]).toMatchObject({ actionOrder: 5, playerName: "Mina", position: "BB", description: "CHECK" });
+  });
+
+  it("falls back safely when old history has no position metadata", () => {
+    const groups = buildReplayTimeline(
+      [{ phase: "BET", event: { type: "BET_ACTION", seat: 4, action: "fold" } }],
+      { seats: [] },
+    );
+    expect(groups[0].rows[0]).toMatchObject({ playerName: "Seat 5", position: "Seat 5", description: "FOLD" });
+  });
+});

--- a/src/ui/screens/replayTimelineViewModel.js
+++ b/src/ui/screens/replayTimelineViewModel.js
@@ -1,0 +1,94 @@
+import { positionLabelForSeat } from "../../games/_core/audit/expectedBettingActor.js";
+
+function normalizedPhase(frame) {
+  return String(frame?.phase ?? frame?.event?.to ?? "EVENT").toUpperCase();
+}
+
+function seatForEvent(event = {}) {
+  const candidates = [event.seat, event.actorSeat, event.playerSeat, event.fromSeat];
+  const seat = candidates.find((value) => Number.isInteger(value) && value >= 0);
+  return Number.isInteger(seat) ? seat : null;
+}
+
+function resolvePositions(handHistory) {
+  const blindEvent = (handHistory?.events ?? []).find((event) => event?.type === "BLINDS_POSTED") ?? {};
+  return {
+    buttonSeat:
+      handHistory?.buttonSeat ?? handHistory?.dealerSeat ?? blindEvent?.buttonSeat ?? null,
+    sbSeat: handHistory?.sbSeat ?? blindEvent?.sbSeat ?? null,
+    bbSeat: handHistory?.bbSeat ?? blindEvent?.bbSeat ?? null,
+  };
+}
+
+function actionDescription(event = {}) {
+  if (event.type === "BET_ACTION") {
+    const action = String(event.action ?? "action").toUpperCase();
+    const amount = Number(event.amount);
+    return `${action}${Number.isFinite(amount) && amount > 0 ? ` ${amount.toLocaleString()}` : ""}`;
+  }
+  if (event.type === "DRAW_ACTION") {
+    const count = Number.isFinite(event.drawCount)
+      ? event.drawCount
+      : Array.isArray(event.discarded)
+        ? event.discarded.length
+        : 0;
+    return count === 0 ? "STAND PAT" : `DRAW ${count}`;
+  }
+  if (event.type === "ANTE_POSTED") return `ANTE ${Number(event.amount ?? 0).toLocaleString()}`;
+  if (event.type === "BLINDS_POSTED") return "BLINDS POSTED";
+  if (event.type === "PHASE_TRANSITION") return `${event.from ?? "?"} → ${event.to ?? "?"}`;
+  if (event.type === "HAND_START") return "HAND START";
+  if (event.type === "SHOWDOWN") return "SHOWDOWN";
+  if (event.type === "HAND_END") return `HAND END · POT ${Number(event.totalPot ?? 0).toLocaleString()}`;
+  return String(event.type ?? "EVENT").replaceAll("_", " ");
+}
+
+export function buildReplayTimeline(frames = [], handHistory = null) {
+  const seats = handHistory?.seats ?? [];
+  const names = new Map(
+    seats.map((entry, index) => [
+      Number.isInteger(entry?.seat) ? entry.seat : index,
+      String(entry?.name ?? `Seat ${index}`),
+    ]),
+  );
+  const positions = resolvePositions(handHistory);
+  const playerCount = seats.length;
+  const phaseCounts = new Map();
+  const groups = [];
+  let priorPhase = null;
+  let actionOrder = 0;
+
+  frames.forEach((frame, frameIndex) => {
+    const phase = normalizedPhase(frame);
+    if (phase !== priorPhase) {
+      const occurrence = (phaseCounts.get(phase) ?? 0) + 1;
+      phaseCounts.set(phase, occurrence);
+      groups.push({ id: `${phase}-${occurrence}`, phase, occurrence, rows: [] });
+      priorPhase = phase;
+    }
+    const event = frame?.event ?? {};
+    const seat = seatForEvent(event);
+    const isPlayerAction = ["BET_ACTION", "DRAW_ACTION", "ANTE_POSTED"].includes(event.type);
+    if (isPlayerAction) actionOrder += 1;
+    const resolvedPosition = seat === null
+      ? null
+      : positionLabelForSeat({ seat, playerCount, ...positions });
+    const position = resolvedPosition && resolvedPosition !== "UNKNOWN"
+      ? resolvedPosition
+      : seat === null
+        ? null
+        : `Seat ${seat + 1}`;
+    const playerName = seat === null ? null : names.get(seat) ?? `Seat ${seat + 1}`;
+    groups.at(-1).rows.push({
+      frame,
+      frameIndex,
+      actionOrder: isPlayerAction ? actionOrder : null,
+      seat,
+      playerName,
+      position,
+      description: actionDescription(event),
+    });
+  });
+
+  return groups;
+}

--- a/tests/e2e/authHelper.ts
+++ b/tests/e2e/authHelper.ts
@@ -240,6 +240,30 @@ export async function createAuthenticatedSession(
   return { email, password, authState };
 }
 
+export async function deleteAuthenticatedSession(
+  page: Page,
+  session: Awaited<ReturnType<typeof createAuthenticatedSession>>,
+) {
+  const token = session?.authState?.accessToken;
+  const scheme = session?.authState?.tokenType ?? "Bearer";
+  if (!token) throw new Error("Cannot delete E2E account without an access token");
+  const deletion = await page.request.delete(`${API_URL}/auth/account`, {
+    headers: { Authorization: `${scheme} ${token}` },
+    data: { password: session.password },
+  });
+  if (!deletion.ok()) {
+    throw new Error(`E2E account deletion failed: ${deletion.status()} ${await deletion.text()}`);
+  }
+  const payload = await deletion.json();
+  if (payload?.deleted !== true) throw new Error("E2E account deletion was not confirmed");
+  const staleAuth = await page.request.get(`${API_URL}/auth/me`, {
+    headers: { Authorization: `${scheme} ${token}` },
+  });
+  if (staleAuth.status() !== 401) {
+    throw new Error(`Deleted E2E account remained accessible: ${staleAuth.status()}`);
+  }
+}
+
 export async function enterTitleIfPresent(page: Page) {
   const titleButton = page.getByTestId("title-enter-button").first();
   if (await titleButton.count()) {
@@ -255,15 +279,16 @@ export async function enterTitleIfPresent(page: Page) {
 }
 
 export async function openAuthenticatedMenu(page: Page, url = APP_URL) {
-  await createAuthenticatedSession(page);
+  const session = await createAuthenticatedSession(page);
   await gotoWithRetry(page, url);
   await dismissTranslateOverlay(page);
   await enterTitleIfPresent(page);
   await page.getByTestId("menu-ring").waitFor({ state: "visible", timeout: 20000 });
+  return session;
 }
 
 export async function openAuthenticatedGame(page: Page, url = APP_URL) {
-  await openAuthenticatedMenu(page, url);
+  const session = await openAuthenticatedMenu(page, url);
   await page.getByTestId("menu-ring").click();
   const variantTestId = variantTestIdFromUrl(url);
   const playButton = page.getByTestId(`game-selector-play-${variantTestId}`).first();
@@ -275,4 +300,5 @@ export async function openAuthenticatedGame(page: Page, url = APP_URL) {
   }
   await page.getByTestId(`game-selector-play-${variantTestId}`).first().click();
   await waitForGameLaunchReady(page);
+  return session;
 }

--- a/tests/e2e/badugi-value-bet-observation.spec.ts
+++ b/tests/e2e/badugi-value-bet-observation.spec.ts
@@ -1,11 +1,16 @@
 import fs from "node:fs";
 import path from "node:path";
 import { expect, test, type Page } from "@playwright/test";
-import { APP_URL, openAuthenticatedGame } from "./authHelper";
+import {
+  APP_URL,
+  deleteAuthenticatedSession,
+  openAuthenticatedGame,
+} from "./authHelper";
 import { getProgressState, invokeE2E, waitForE2EDriver } from "./helpers/gameProgressHelper.js";
 
 const REPORT_DIR = path.resolve("reports/ai");
 const REPORT_PATH = path.join(REPORT_DIR, "badugi-value-bet-live-observation.json");
+const AI_TIER_OVERRIDE = process.env.E2E_AI_TIER_OVERRIDE?.trim() || null;
 
 function ensureReportDir() {
   fs.mkdirSync(REPORT_DIR, { recursive: true });
@@ -25,12 +30,16 @@ function countBy<T extends string>(values: T[]) {
 }
 
 async function openBadugiRuntime(page: Page, mode: "cash" | "tournament") {
-  await page.addInitScript(() => {
+  await page.addInitScript((tierOverride) => {
     window.localStorage.setItem("mgx.previewVariants", "true");
-    window.localStorage.removeItem("dev.aiTierOverride");
+    if (tierOverride) {
+      window.localStorage.setItem("dev.aiTierOverride", tierOverride);
+    } else {
+      window.localStorage.removeItem("dev.aiTierOverride");
+    }
     window.__MGX_CPU_DECISION_TRACE__ = [];
-  });
-  await openAuthenticatedGame(page, `${APP_URL}?variant=badugi&mode=${mode}&mgxQa=mobile`);
+  }, AI_TIER_OVERRIDE);
+  const session = await openAuthenticatedGame(page, `${APP_URL}?variant=badugi&mode=${mode}&mgxQa=mobile`);
   await waitForE2EDriver(page);
   if (mode === "tournament") {
     await invokeE2E(page, "startTournamentMTT", {
@@ -52,6 +61,7 @@ async function openBadugiRuntime(page: Page, mode: "cash" | "tournament") {
   await page.evaluate(() => {
     window.__MGX_CPU_DECISION_TRACE__ = [];
   });
+  return session;
 }
 
 async function clickHeroIfNeeded(page: Page) {
@@ -153,12 +163,16 @@ test("Badugi live CPU telemetry classifies friend-alpha runtime path and pressur
   const summaries = [];
 
   for (const mode of ["cash", "tournament"] as const) {
-    await openBadugiRuntime(page, mode);
-    const rows = await collectCpuTrace(page, mode === "tournament" ? 6 : 8);
-    const summary = summarizeRows(mode, rows);
-    summaries.push(summary);
-    expect(summary.decisions, `${mode} CPU telemetry rows`).toBeGreaterThan(0);
-    expect(summary.decisionSources, `${mode} source attribution`).not.toEqual({ unknown: summary.decisions });
+    const session = await openBadugiRuntime(page, mode);
+    try {
+      const rows = await collectCpuTrace(page, mode === "tournament" ? 6 : 8);
+      const summary = summarizeRows(mode, rows);
+      summaries.push(summary);
+      expect(summary.decisions, `${mode} CPU telemetry rows`).toBeGreaterThan(0);
+      expect(summary.decisionSources, `${mode} source attribution`).not.toEqual({ unknown: summary.decisions });
+    } finally {
+      await deleteAuthenticatedSession(page, session);
+    }
   }
 
   const aggregateRows = summaries.flatMap((summary) => summary.sampleRows);
@@ -176,6 +190,7 @@ test("Badugi live CPU telemetry classifies friend-alpha runtime path and pressur
   );
   const report = {
     generatedAt: new Date().toISOString(),
+    requestedTierOverride: AI_TIER_OVERRIDE,
     liveClassification,
     passiveConfirmed,
     summaries,

--- a/tests/e2e/helpers/liveCore5Helper.ts
+++ b/tests/e2e/helpers/liveCore5Helper.ts
@@ -66,6 +66,32 @@ export async function createLiveAuthenticatedSession(page: Page) {
   await page.addInitScript((state) => {
     window.localStorage.setItem("mgx_auth", JSON.stringify(state));
   }, authState);
+
+  let deleted = false;
+  return {
+    email,
+    async deleteAccount() {
+      if (deleted) return;
+      const deletion = await page.request.delete(`${LIVE_API_URL}/auth/account`, {
+        headers: { Authorization: `${scheme} ${token}` },
+        data: { password: DEFAULT_PASSWORD },
+      });
+      if (!deletion.ok()) {
+        throw new Error(`Live account deletion failed: ${deletion.status()} ${await deletion.text()}`);
+      }
+      const payload = await deletion.json();
+      if (payload?.deleted !== true) {
+        throw new Error("Live account deletion did not confirm deleted=true");
+      }
+      const staleAuth = await page.request.get(`${LIVE_API_URL}/auth/me`, {
+        headers: { Authorization: `${scheme} ${token}` },
+      });
+      if (staleAuth.status() !== 401) {
+        throw new Error(`Deleted live account remained accessible: ${staleAuth.status()}`);
+      }
+      deleted = true;
+    },
+  };
 }
 
 export async function gotoLiveWithRetry(page: Page, url = LIVE_URL, timeout = 60000) {
@@ -98,14 +124,15 @@ async function enterTitleIfPresent(page: Page) {
 }
 
 export async function openLiveMenu(page: Page, url = LIVE_URL) {
-  await createLiveAuthenticatedSession(page);
+  const session = await createLiveAuthenticatedSession(page);
   await gotoLiveWithRetry(page, url);
   await enterTitleIfPresent(page);
   await page.getByTestId("menu-ring").waitFor({ state: "visible", timeout: 30000 });
+  return session;
 }
 
 export async function openLiveGame(page: Page, variant: Core5Variant | { variant: string }) {
-  await openLiveMenu(page, `${LIVE_URL}?variant=${variant.variant}&buildInfo=1`);
+  const session = await openLiveMenu(page, `${LIVE_URL}?variant=${variant.variant}&buildInfo=1`);
   await page.getByTestId("menu-ring").click();
   const canonical = {
     badugi: "badugi",
@@ -128,6 +155,7 @@ export async function openLiveGame(page: Page, variant: Core5Variant | { variant
   }
   await waitForE2EDriver(page);
   await page.getByTestId("decision-panel").waitFor({ state: "visible", timeout: 30000 });
+  return session;
 }
 
 export async function openLiveMobileContext(browser: Browser, viewport: LiveLayoutViewport) {
@@ -149,7 +177,7 @@ export async function closeLiveContext(context: BrowserContext) {
 }
 
 export async function openLiveTournament(page: Page, variant: Core5Variant) {
-  await openLiveGame(page, variant);
+  const session = await openLiveGame(page, variant);
   await page.waitForFunction(
     () => typeof window.__BADUGI_E2E__?.startTournamentMTT === "function",
     undefined,
@@ -171,6 +199,7 @@ export async function openLiveTournament(page: Page, variant: Core5Variant) {
   }, variant.variant);
   await page.getByTestId("decision-panel").waitFor({ state: "visible", timeout: 30000 });
   await page.getByTestId("tournament-hud").waitFor({ state: "visible", timeout: 30000 });
+  return session;
 }
 
 export async function getLiveBuildInfo(page: Page) {

--- a/tests/e2e/live-core5-alpha-smoke.spec.ts
+++ b/tests/e2e/live-core5-alpha-smoke.spec.ts
@@ -67,39 +67,50 @@ async function playToResultOrBudget(page: Page, variant: Core5Variant, mode: Smo
 async function runModeSmoke(page: Page, variant: Core5Variant, mode: SmokeMode) {
   const browserErrors = captureFatalBrowserErrors(page);
   const issues: string[] = [];
+  let liveSession: Awaited<ReturnType<typeof openLiveGame>> | null = null;
 
-  if (mode === "tournament") {
-    await openLiveTournament(page, variant);
-  } else {
-    await openLiveGame(page, variant);
+  try {
+    if (mode === "tournament") {
+      liveSession = await openLiveTournament(page, variant);
+    } else {
+      liveSession = await openLiveGame(page, variant);
+    }
+
+    // A previous document may still be cancelling asynchronous work while the
+    // new live route loads. Only classify errors emitted by the active game.
+    browserErrors.length = 0;
+
+    await expect(page.getByTestId("game-table-surface")).toBeVisible({ timeout: 30000 });
+    await expect(page.getByTestId("table-total-pot")).toBeVisible({ timeout: 30000 });
+    await expect(page.getByTestId("decision-panel")).toBeVisible({ timeout: 30000 });
+    if (mode === "tournament") {
+      await expect(page.getByTestId("tournament-hud")).toBeVisible({ timeout: 30000 });
+    }
+
+    const result = await playToResultOrBudget(page, variant, mode);
+    if (!result.resultReached) issues.push("RESULT_NOT_REACHED");
+    if (mode === "cash" && !result.nextHandWorked) issues.push("NEXT_HAND_NOT_CONFIRMED");
+
+    for (const message of browserErrors) {
+      if (/favicon|ResizeObserver loop|Failed to load resource/i.test(message)) continue;
+      if (/wasm streaming compile failed|falling back to ArrayBuffer instantiation/i.test(message)) continue;
+      issues.push(`BROWSER_FATAL:${message}`);
+    }
+
+    return {
+      game: variant.game,
+      variantId: variant.variant,
+      mode,
+      status: issues.length ? "FAIL" : "PASS",
+      issues,
+      resultReached: result.resultReached,
+      nextHandWorked: result.nextHandWorked,
+      checkpoints: result.checkpoints.slice(-10),
+      accountDeleted: true,
+    };
+  } finally {
+    await liveSession?.deleteAccount();
   }
-
-  await expect(page.getByTestId("game-table-surface")).toBeVisible({ timeout: 30000 });
-  await expect(page.getByTestId("table-total-pot")).toBeVisible({ timeout: 30000 });
-  await expect(page.getByTestId("decision-panel")).toBeVisible({ timeout: 30000 });
-  if (mode === "tournament") {
-    await expect(page.getByTestId("tournament-hud")).toBeVisible({ timeout: 30000 });
-  }
-
-  const result = await playToResultOrBudget(page, variant, mode);
-  if (!result.resultReached) issues.push("RESULT_NOT_REACHED");
-  if (mode === "cash" && !result.nextHandWorked) issues.push("NEXT_HAND_NOT_CONFIRMED");
-
-  for (const message of browserErrors) {
-    if (/favicon|ResizeObserver loop|Failed to load resource/i.test(message)) continue;
-    issues.push(`BROWSER_FATAL:${message}`);
-  }
-
-  return {
-    game: variant.game,
-    variantId: variant.variant,
-    mode,
-    status: issues.length ? "FAIL" : "PASS",
-    issues,
-    resultReached: result.resultReached,
-    nextHandWorked: result.nextHandWorked,
-    checkpoints: result.checkpoints.slice(-10),
-  };
 }
 
 test.describe("Live Core5 alpha smoke", () => {

--- a/tests/e2e/live-p2p-friend-match.spec.ts
+++ b/tests/e2e/live-p2p-friend-match.spec.ts
@@ -1,0 +1,142 @@
+import { expect, test, type BrowserContext, type Page } from "@playwright/test";
+
+import {
+  APP_URL,
+  API_URL,
+  createAuthenticatedSession,
+  gotoWithRetry,
+} from "./authHelper";
+
+const LIVE_ENABLED = process.env.MGX_LIVE_P2P === "1";
+type AuthSession = Awaited<ReturnType<typeof createAuthenticatedSession>>;
+let cleanupSessions: AuthSession[] = [];
+
+async function deleteLiveSession(session: AuthSession) {
+  const token = session.authState.accessToken;
+  const authorization = `${session.authState.tokenType} ${token}`;
+  const deletion = await fetch(`${API_URL}/auth/account`, {
+    method: "DELETE",
+    headers: { Authorization: authorization, "Content-Type": "application/json" },
+    body: JSON.stringify({ password: session.password }),
+  });
+  expect(deletion.status, await deletion.text()).toBe(200);
+  const stale = await fetch(`${API_URL}/auth/me`, { headers: { Authorization: authorization } });
+  expect(stale.status).toBe(401);
+}
+
+async function openFriendMatch(page: Page) {
+  const session = await createAuthenticatedSession(page);
+  await gotoWithRetry(page, `${APP_URL}friend-match`);
+  await expect(page.getByRole("heading", { name: /Create a Room|プライベート卓を作成/i })).toBeVisible();
+  return session;
+}
+
+async function privateCards(page: Page) {
+  const cards = page.getByTestId("p2p-private-hand").locator("button");
+  await expect(cards).toHaveCount(4, { timeout: 20_000 });
+  return cards.allTextContents();
+}
+
+async function waitForActor(pages: Page[], ids: string[]) {
+  const deadline = Date.now() + 20_000;
+  while (Date.now() < deadline) {
+    for (const page of pages) {
+      for (const id of ids) {
+        if (await page.locator(`[data-testid="${id}"]:not([disabled])`).count()) return { page, id };
+      }
+    }
+    await new Promise((resolve) => setTimeout(resolve, 100));
+  }
+  throw new Error(`No enabled P2P action: ${ids.join(", ")}`);
+}
+
+test.describe("live P2P friend match", () => {
+  test.skip(!LIVE_ENABLED, "Set MGX_LIVE_P2P=1 to run against an explicitly selected live environment");
+  test.describe.configure({ timeout: 150_000 });
+  test.afterEach(async () => {
+    const sessions = cleanupSessions;
+    cleanupSessions = [];
+    for (const session of sessions.reverse()) await deleteLiveSession(session);
+  });
+
+  test("two real accounts create, join, reconnect, act privately, leave, and are deleted", async ({ browser }) => {
+    const options: Parameters<typeof browser.newContext>[0] = {
+      viewport: { width: 844, height: 390 },
+      isMobile: true,
+      hasTouch: true,
+      deviceScaleFactor: 2,
+      serviceWorkers: "block",
+    };
+    const hostContext: BrowserContext = await browser.newContext(options);
+    const guestContext: BrowserContext = await browser.newContext(options);
+    const host = await hostContext.newPage();
+    const guest = await guestContext.newPage();
+    let hostSession: Awaited<ReturnType<typeof createAuthenticatedSession>> | null = null;
+    let guestSession: Awaited<ReturnType<typeof createAuthenticatedSession>> | null = null;
+
+    try {
+      hostSession = await openFriendMatch(host);
+      cleanupSessions.push(hostSession);
+      const createResponses: Array<{ url: string; status: number; method: string }> = [];
+      host.on("response", (response) => {
+        createResponses.push({
+          url: response.url(),
+          status: response.status(),
+          method: response.request().method(),
+        });
+      });
+      await host.getByRole("button", { name: /Create Room|ルームを作成/i }).click();
+      await expect(host.locator("strong").filter({ hasText: /^[A-Z2-9]{6}$/ }).first()).toBeVisible({ timeout: 20_000 }).catch(async () => {
+        throw new Error(`P2P create did not produce a room: ${JSON.stringify({
+          status: await host.locator("p").allTextContents(),
+          responses: createResponses.filter((entry) => entry.method === "POST"),
+        })}`);
+      });
+      expect(createResponses).toContainEqual({ url: `${API_URL}/p2p/rooms`, status: 200, method: "POST" });
+      const roomCode = (
+        await host.locator("strong").filter({ hasText: /^[A-Z2-9]{6}$/ }).first().textContent()
+      )?.trim();
+      expect(roomCode).toMatch(/^[A-Z2-9]{6}$/);
+
+      guestSession = await openFriendMatch(guest);
+      cleanupSessions.push(guestSession);
+      await guest.getByLabel(/Room code|ルームコード/i).fill(roomCode!);
+      const [joinResponse] = await Promise.all([
+        guest.waitForResponse((response) => response.url().includes("/p2p/") && response.request().method() === "POST", { timeout: 20_000 }),
+        guest.getByRole("button", { name: /^Join$|^参加$/i }).click(),
+      ]);
+      expect(joinResponse.status(), await joinResponse.text()).toBe(200);
+      await expect(host.getByText(/^(connected|polling)$/i)).toBeVisible({ timeout: 20_000 });
+      await expect(guest.getByText(/^(connected|polling)$/i)).toBeVisible({ timeout: 20_000 });
+      await host.getByTestId("p2p-ready").click();
+      await guest.getByTestId("p2p-ready").click();
+
+      const hostCards = await privateCards(host);
+      const guestCards = await privateCards(guest);
+      expect(new Set([...hostCards, ...guestCards]).size).toBe(8);
+      expect(await host.getByTestId("p2p-private-hand").textContent()).not.toContain(guestCards.join(" "));
+      expect(await guest.getByTestId("p2p-private-hand").textContent()).not.toContain(hostCards.join(" "));
+
+      await host.reload({ waitUntil: "load" });
+      await expect(host.getByText(/^(connected|polling)$/i)).toBeVisible({ timeout: 20_000 });
+      expect(await privateCards(host)).toEqual(hostCards);
+      const geometry = await host.evaluate(() => ({
+        scrollWidth: document.documentElement.scrollWidth,
+        clientWidth: document.documentElement.clientWidth,
+      }));
+      expect(geometry.scrollWidth).toBeLessThanOrEqual(geometry.clientWidth + 1);
+
+      const opener = await waitForActor([host, guest], ["p2p-call", "p2p-check"]);
+      await opener.page.getByTestId(opener.id).click();
+      const responder = opener.page === host ? guest : host;
+      const reply = await waitForActor([responder], ["p2p-check", "p2p-call"]);
+      await reply.page.getByTestId(reply.id).click();
+
+      await guest.getByTestId("p2p-leave").click();
+      await expect(guest.getByRole("heading", { name: /Create a Room|プライベート卓を作成/i })).toBeVisible();
+    } finally {
+      await hostContext.close().catch(() => {});
+      await guestContext.close().catch(() => {});
+    }
+  });
+});

--- a/tests/e2e/tournament-stage-blind-transition.spec.ts
+++ b/tests/e2e/tournament-stage-blind-transition.spec.ts
@@ -535,6 +535,71 @@ test("Local runs from its production field through ante levels to a verified cha
   }));
 });
 
+test("World runs from its 275-player production field through FT to a verified champion and review", async ({
+  page,
+}) => {
+  test.setTimeout(900_000);
+  const completed = await completeProductionTournament(page, "world");
+  expect(completed.config).toMatchObject({ totalPlayers: 275, tables: 46 });
+  expect(completed.realHeroHands).toBeGreaterThan(0);
+  expect(completed.levelsVisited.length).toBeGreaterThan(1);
+  expect(completed.hud.milestoneEvents).toEqual(
+    expect.arrayContaining(["FINAL_TABLE", "TOP_THREE", "HEADS_UP"]),
+  );
+  expect(completed.review.reviewDepth).toBe("hand-history");
+  console.info("[MTT_COMPLETION]", JSON.stringify({
+    stageId: "world",
+    realHeroHands: completed.realHeroHands,
+    backgroundHands: completed.hud.abstractHandCounter,
+    finalLevel: completed.hud.currentLevelNumber,
+    heroPlace: completed.hud.heroFinishPlace,
+    championId: completed.hud.championId,
+  }));
+});
+
+test("World never offers re-entry after an FT bust and only offers a new event after completion", async ({
+  page,
+}) => {
+  test.setTimeout(180_000);
+  const config = await startProductionStage(page, "world");
+  expect(config.reentryPolicy).toEqual({
+    allowed: false,
+    maxEntries: 1,
+    closesAtLevel: 0,
+  });
+  await page.evaluate((worldConfig) => {
+    window.__BADUGI_E2E__.startTournamentMTT({
+      ...worldConfig,
+      id: "world-ft-reentry-contract",
+      totalPlayers: 6,
+      tables: 1,
+    });
+  }, config);
+  await expect(page.getByTestId("tournament-hud")).toBeVisible();
+  await expect(page.getByRole("button", { name: /re-?entry|re-?enter/i })).toHaveCount(0);
+  await expect(page.getByRole("button", { name: "Enter New Tournament" })).toHaveCount(0);
+
+  const state = await page.evaluate(() =>
+    window.__BADUGI_E2E__.simulateTournamentBackground(1),
+  );
+  expect(state.playersRemaining).toBeLessThanOrEqual(6);
+  expect(state.isFinished).toBe(false);
+  expect(state.tables.filter((table) => table.isActive)).toHaveLength(1);
+
+  const busted = await page.evaluate(() => window.__BADUGI_E2E__.forceHeroBust());
+  expect(busted.players["hero-player"]).toMatchObject({ busted: true });
+  expect(busted.isFinished).toBe(false);
+  await expect(page.getByRole("button", { name: /re-?entry|re-?enter/i })).toHaveCount(0);
+  await expect(page.getByRole("button", { name: "Enter New Tournament" })).toHaveCount(0);
+
+  const completed = await page.evaluate(() =>
+    window.__BADUGI_E2E__.fastForwardMTTComplete(),
+  );
+  expect(completed).toMatchObject({ isFinished: true, playersRemaining: 1 });
+  await expect(page.getByRole("button", { name: /re-?entry|re-?enter/i })).toHaveCount(0);
+  await expect(page.getByRole("button", { name: "Enter New Tournament" })).toBeVisible();
+});
+
 for (const stage of [
   { stageId: "store", entryFee: 0, payout: 1_000, netResult: 1_000 },
   { stageId: "local", entryFee: 1_000, payout: 12_000, netResult: 11_000 },


### PR DESCRIPTION
## Outcome
Completes the second MGX quality program after the initial release integration and production smoke.

## Product changes
- World Championship production-size run to FT/champion, plus FT bust/no-reentry contract
- readable replay timeline grouped by street with action order, player names and positions
- Chinese Poker exact hand ledger, persistent history and deterministic row/scoring replay
- production P2P lifecycle smoke with independent test-account deletion

## Permanent QA/QM
- required exact cash + 35-variant history replay CI job
- nightly production Core5/P2P smoke and standard/pro telemetry matrix
- current `/friend-match` SPA asset verification during deploy
- Node 24-compatible official GitHub action majors

## Evidence
- lint/build/ONNX asset PASS
- Tier1 303 files / 2,072 tests; Tier2 78 / 165
- backend 69; progression 170; EV 25; audit 0 vulnerabilities
- P2P UI 17 + WS E2E + forced REST fallback E2E PASS
- production P2P create/join/privacy/reload/action/leave/delete PASS
- exact history 36/36 browser tests PASS
- World: 275 entrants / 46 tables, 44 real Hero hands + 796 background hands, final level 18, one champion
- Chinese controller/history/UI 10/10 PASS

## Explicit boundaries
- Production P2P is currently usable through bounded authenticated REST polling when WSS is unavailable.
- Classic Chinese Poker is covered; OFC street-by-street/Fantasyland remains a separate feature.
- Badugi pro-overlay is heuristic; the Windows-trained ONNX checkpoint is not represented as directly deployed inference.
