### PR TITLE
fix(ci): target production in live telemetry matrix

### DIFF
--- a/.github/workflows/production-live-nightly.yml
+++ b/.github/workflows/production-live-nightly.yml
@@ -59,6 +59,7 @@ jobs:
       - run: npx playwright install --with-deps chromium
       - name: Validate live Badugi decision telemetry
         env:
+          E2E_APP_URL: https://mgx-poker.com/
           E2E_AI_TIER_OVERRIDE: ${{ matrix.ai-tier }}
         run: npx playwright test tests/e2e/badugi-value-bet-observation.spec.ts --project=badugi-flow
       - uses: actions/upload-artifact@v4


### PR DESCRIPTION
Adds the missing E2E_APP_URL to the standard/pro nightly telemetry matrix. Verified both tiers directly against https://mgx-poker.com/; both passed and deleted their test accounts.