### PR TITLE
fix(tournament): make hand boundaries and blinds exact

### DIFF
--- a/docs/testing/MGX_QUALITY_PROGRAM_20260828.md
+++ b/docs/testing/MGX_QUALITY_PROGRAM_20260828.md
@@ -24,7 +24,7 @@ QA/QM result: **PASS for the 1–10 implementation scope**. Tasks 1–4 were int
 - ESLint: PASS.
 - Production build: PASS; ONNX WASM asset 23,824,254 bytes.
 - Dependency audit: 0 vulnerabilities.
-- Tier1: 303 files / 2,072 tests PASS.
+- Tier1: 303 files / 2,073 tests PASS.
 - Tier2: 78 files / 165 tests PASS.
 - Backend: 69 tests PASS, including deletion, P2P persistence, migration and tournament state.
 - Game progression: 170 tests PASS; game EV: 25 tests PASS.
@@ -32,9 +32,9 @@ QA/QM result: **PASS for the 1–10 implementation scope**. Tasks 1–4 were int
 - Production P2P: create/join/privacy/reload/action/leave/delete PASS in 13.8 seconds.
 - Cash exact history replay: PASS.
 - Tournament exact history replay: PASS.
-- Store completion: 35 real Hero hands + 53 background hands; champion verified.
-- Local completion: 25 real Hero hands + 140 background hands; ante level and champion verified.
-- World completion: 44 real Hero hands + 796 background hands; final level 18 and champion verified.
+- Store completion: 37 real Hero hands + 57 background hands; level 12 and champion verified.
+- Local completion: 15 real Hero hands + 150 background hands; level 11, ante and champion verified.
+- World completion: 32 real Hero hands + 807 background hands; 275-player field, FT/top three/heads-up, level 17 and champion verified.
 - Store/local Hero-champion paths produce grounded post-tournament reviews.
 - Chinese Poker controller/history/UI: 10 tests PASS; replay integrity is surfaced in the result screen.
 
@@ -46,6 +46,9 @@ QA/QM result: **PASS for the 1–10 implementation scope**. Tasks 1–4 were int
 4. Nightly production QA runs Core5 cash/tournament and P2P lifecycle checks with screenshots/artifacts retained for 14 days.
 5. Nightly AI QA runs standard and pro telemetry separately; test users are deleted and stale tokens must return 401.
 6. Test failures record screenshots and browser artifacts; production P2P cleanup is independent of the page lifecycle so timeout does not skip deletion.
+7. Tournament QA advances only when the visible result hand ID is replaced by a new physical hand ID. Re-reading one result can no longer masquerade as hundreds of completed hands.
+8. Tournament blind displays use the MTT engine's completed-hand counter as the authority. Store/local fifth-hand boundary tests prevent the ring controller from advancing a level one hand early.
+9. Tournament completion is idempotent by table and hand ID, and a Next Hand request made during the short deal lock is queued once instead of being discarded or double-dealt.
 
 ## Explicit boundaries
 

--- a/src/games/badugi/engine/__tests__/tournamentMTT.test.js
+++ b/src/games/badugi/engine/__tests__/tournamentMTT.test.js
@@ -224,6 +224,23 @@ describe("tournamentMTT engine", () => {
     expect(state.tables[0].handsPlayedAtThisLevel).toBe(2);
   });
 
+  it("counts the same completed hand exactly once across showdown callbacks", () => {
+    const initial = createMTTTournamentState(BASE_CONFIG, entrants);
+    const tableId = initial.tables[0].tableId;
+    const completion = {
+      handId: "table-1-hand-1",
+      handIndex: 1,
+      seatResults: [],
+    };
+
+    const once = onTableHandCompleted(initial, tableId, completion);
+    const duplicate = onTableHandCompleted(once, tableId, completion);
+
+    expect(duplicate).toBe(once);
+    expect(duplicate.tables[0].handsPlayedAtThisLevel).toBe(1);
+    expect(duplicate.completedHandIds).toEqual(["table-1:table-1-hand-1"]);
+  });
+
   it("marks players busted and reduces playersRemaining", () => {
     let state = createMTTTournamentState(BASE_CONFIG, entrants);
     const targetTable = state.tables[0];

--- a/src/games/badugi/engine/tournamentMTT.js
+++ b/src/games/badugi/engine/tournamentMTT.js
@@ -91,6 +91,7 @@ export function createMTTTournamentState(config, entrants) {
     championId: null,
     finishOrder: [],
     abstractHandCounter: 0,
+    completedHandIds: [],
     events: [],
     lastEvent: null,
   };
@@ -117,6 +118,7 @@ function cloneState(state) {
       Object.entries(state.players).map(([id, player]) => [id, { ...player }]),
     ),
     finishOrder: [...(state.finishOrder ?? [])],
+    completedHandIds: [...(state.completedHandIds ?? [])],
     events: (state.events ?? []).map((event) => ({ ...event })),
     lastEvent: state.lastEvent ? { ...state.lastEvent } : null,
   };
@@ -127,12 +129,22 @@ function cloneState(state) {
  * @param {TournamentStateMTT} state
  * @param {string} tableId
  * @param {{
+ *   handId?: string,
  *   handIndex?: number,
  *   seatResults: Array<{ seatIndex: number, playerId: string, stack: number, startingStack?: number }>
  * }} handSummary
  */
 export function onTableHandCompleted(state, tableId, handSummary) {
   if (state.isFinished) return state;
+  const completionKey = handSummary?.handId
+    ? `${tableId}:${handSummary.handId}`
+    : null;
+  // The UI has more than one showdown completion path for compatibility with
+  // controller and legacy games.  They may converge on the same real hand;
+  // tournament progression must remain exactly-once even if both report it.
+  if (completionKey && (state.completedHandIds ?? []).includes(completionKey)) {
+    return state;
+  }
   const next = cloneState(state);
   const table = next.tables.find((t) => t.tableId === tableId);
   if (!table) {
@@ -169,6 +181,12 @@ export function onTableHandCompleted(state, tableId, handSummary) {
   }
 
   table.handsPlayedAtThisLevel += 1;
+  if (completionKey) {
+    next.completedHandIds.push(completionKey);
+    if (next.completedHandIds.length > 4096) {
+      next.completedHandIds.splice(0, next.completedHandIds.length - 4096);
+    }
+  }
   maybeAdvanceLevel(next);
   maybeRebalance(next);
   maybeFinalizeTournament(next);
@@ -716,6 +734,7 @@ function sanitizeStack(value) {
  * @property {boolean} isFinished
  * @property {string|null} championId
  * @property {string[]} finishOrder
+ * @property {string[]} completedHandIds
  * @property {Array<Object>} events
  * @property {Object|null} lastEvent
  */

--- a/src/ui/App.jsx
+++ b/src/ui/App.jsx
@@ -2692,6 +2692,7 @@ export default function App() {
   const [showNextButton, setShowNextButton] = useState(false);
 
   const handSavedRef = useRef(false);
+  const tournamentCompletedHandIdRef = useRef(null);
   const sentHandIdsRef = useRef(new Set());
   const handIdRef = useRef(null);
   const showdownTokenRef = useRef(0);
@@ -3584,6 +3585,12 @@ export default function App() {
 
   function setPlayerSnapshot(snap) {
     const normalized = sanitizePlayerSnapshotForVariant(snap);
+    // Action handlers intentionally read playersRef so consecutive controller
+    // transitions do not wait for a React render.  Keep that authoritative
+    // snapshot in lockstep with the rendered state; otherwise a late DRAW
+    // action can be followed by another transition built from the stale
+    // pre-draw players and leave the hero action permanently visible.
+    playersRef.current = normalized;
     setPlayers(normalized);
     return normalized;
   }
@@ -6219,6 +6226,39 @@ export default function App() {
     totalPotRef.current = totalPotForDisplay;
   }, [totalPotForDisplay]);
 
+  function applyHeroTournamentHandCompletion(playersSnapshot) {
+    if (mode !== "tournament-mtt" || !tournamentStateRef.current) return null;
+    const completedHandId = handIdRef.current;
+    if (
+      completedHandId &&
+      tournamentCompletedHandIdRef.current === completedHandId
+    ) {
+      return tournamentStateRef.current;
+    }
+    const tournamentSummary =
+      buildTournamentHandSummaryFromPlayers(playersSnapshot);
+    if (!tournamentSummary) return null;
+    // Mark before updating React/tournament state. Both the controller and the
+    // legacy showdown callback can report the same physical hand in one tick.
+    // Advancing blinds/eliminations twice is never valid.
+    tournamentCompletedHandIdRef.current = completedHandId;
+    const tableId = heroTableIdRef.current ?? heroTableMetaRef.current.tableId;
+    recordHeroHandForReplay(tableId, tournamentSummary);
+    let nextState = onTableHandCompleted(
+      tournamentStateRef.current,
+      tableId,
+      tournamentSummary,
+    );
+    if (!nextState.isFinished) {
+      nextState = simulateBackgroundTables(nextState, tableId, {
+        maxHandsPerTable: 1,
+        onHandSimulated: recordCpuHandForReplay,
+      });
+    }
+    applyTournamentStateUpdate(nextState);
+    return nextState;
+  }
+
   function goShowdownNow(playersSnap, options = {}) {
     debugLog("[SHOWDOWN] goShowdownNow (All-in shortcut) called");
     if (tableMetadataRef.current?.endTimestamp) {
@@ -6478,26 +6518,7 @@ export default function App() {
         `Seat ${p.name}: ${(p.hand ?? []).join(" ")} | type=${rankLabel} ranks=${rankValues}`,
       );
     });
-    if (mode === "tournament-mtt" && tournamentStateRef.current) {
-      const tournamentSummary = buildTournamentHandSummaryFromPlayers(updated);
-      if (tournamentSummary) {
-        const tableId =
-          heroTableIdRef.current ?? heroTableMetaRef.current.tableId;
-        recordHeroHandForReplay(tableId, tournamentSummary);
-        let nextState = onTableHandCompleted(
-          tournamentStateRef.current,
-          tableId,
-          tournamentSummary,
-        );
-        if (!nextState.isFinished) {
-          nextState = simulateBackgroundTables(nextState, tableId, {
-            maxHandsPerTable: 1,
-            onHandSimulated: recordCpuHandForReplay,
-          });
-        }
-        applyTournamentStateUpdate(nextState);
-      }
-    }
+    applyHeroTournamentHandCompletion(updated);
     triggerRotationAndRefreshHud("hand");
     console.log("[SHOWDOWN] Waiting for Next Hand button...");
   }
@@ -6532,6 +6553,7 @@ export default function App() {
   );
 
   const dealingRef = useRef(false);
+  const pendingNextHandRetryRef = useRef(null);
   const startNextHandRef = useRef(() => {});
 
   const resetTournamentState = useCallback(() => {
@@ -7324,8 +7346,27 @@ export default function App() {
         return initialDealResult?.hands?.[seat] ?? [];
       };
       const fallbackStack = startingStackRef.current;
-      const blindLevelSnapshot = blindLevelIndexRef.current ?? 0;
-      const handsInLevelSnapshot = handsInLevelRef.current ?? 0;
+      const tournamentBlindAuthority = activeHandIsTournament
+        ? tournamentStateRef.current
+        : null;
+      const tournamentHeroTableId =
+        heroTableIdRef.current ?? heroTableMetaRef.current?.tableId ?? null;
+      const tournamentHeroTable = tournamentBlindAuthority?.tables?.find(
+        (table) => table?.tableId === tournamentHeroTableId,
+      );
+      // Ring controllers count dealt hands. MTT levels count completed hands
+      // across active tables. Never feed the ring counter back into an MTT
+      // deal: duplicate initial/render triggers can otherwise advance blinds
+      // one hand early even though the tournament engine is still correct.
+      const blindLevelSnapshot = tournamentBlindAuthority
+        ? Math.max(0, Number(tournamentBlindAuthority.levelIndex) || 0)
+        : (blindLevelIndexRef.current ?? 0);
+      const handsInLevelSnapshot = tournamentBlindAuthority
+        ? Math.max(
+            0,
+            Number(tournamentHeroTable?.handsPlayedAtThisLevel) || 0,
+          )
+        : (handsInLevelRef.current ?? 0);
       const handBlindStructure = activeHandIsTournament
         ? getBlindStructureForTournamentConfig(
             tournamentStateRef.current?.config ??
@@ -7576,8 +7617,16 @@ export default function App() {
         });
       }
 
-      setBlindLevelIndex(resolvedBlindIdx);
-      setHandsInLevel(resolvedHandCount);
+      const authoritativeBlindIndex = tournamentBlindAuthority
+        ? blindLevelSnapshot
+        : resolvedBlindIdx;
+      const authoritativeCompletedHands = tournamentBlindAuthority
+        ? Math.max(1, handsInLevelSnapshot)
+        : resolvedHandCount;
+      blindLevelIndexRef.current = authoritativeBlindIndex;
+      handsInLevelRef.current = authoritativeCompletedHands;
+      setBlindLevelIndex(authoritativeBlindIndex);
+      setHandsInLevel(authoritativeCompletedHands);
 
       handStartingStacksRef.current = handStartingStacksById;
       seatOutWarnings.forEach((msg) => console.warn(msg));
@@ -7616,6 +7665,7 @@ export default function App() {
       };
       handSavedRef.current = false;
       handIdRef.current = newHandId;
+      tournamentCompletedHandIdRef.current = null;
       if (legacyGameController?.state) {
         legacyGameController.state.metadata = {
           ...(legacyGameController.state.metadata ?? {}),
@@ -7988,9 +8038,38 @@ export default function App() {
   const startNextHand = useCallback(
     ({ dealerOverride = null, prevPlayers = null } = {}) => {
       if (dealingRef.current) {
-        console.warn("[HAND] dealNewHand busy; next request ignored");
-        return false;
+        // A very short/all-in hand can expose its result before the previous
+        // deal's 100ms safety lock is released.  Do not lose the user's Next
+        // hand click in that window.  Keep one bounded, idempotent retry; a
+        // second click updates nothing and cannot deal twice.
+        if (!pendingNextHandRetryRef.current) {
+          const retry = { dealerOverride, prevPlayers, attempts: 0 };
+          pendingNextHandRetryRef.current = retry;
+          const retryWhenUnlocked = () => {
+            if (pendingNextHandRetryRef.current !== retry) return;
+            retry.attempts += 1;
+            if (dealingRef.current && retry.attempts < 20) {
+              setTimeout(retryWhenUnlocked, 100);
+              return;
+            }
+            pendingNextHandRetryRef.current = null;
+            if (dealingRef.current) {
+              console.error(
+                "[HAND] next-hand retry exhausted while deal lock remained active",
+              );
+              return;
+            }
+            startNextHandRef.current({
+              dealerOverride: retry.dealerOverride,
+              prevPlayers: retry.prevPlayers,
+            });
+          };
+          setTimeout(retryWhenUnlocked, 100);
+        }
+        console.warn("[HAND] dealNewHand busy; next request queued");
+        return true;
       }
+      pendingNextHandRetryRef.current = null;
       if (tournamentBreakStateRef.current) {
         if (Number(tournamentBreakStateRef.current.endsAt) > Date.now()) {
           console.warn("[MTT] next hand blocked during scheduled break");
@@ -9344,6 +9423,27 @@ export default function App() {
       },
       resolveHandNow: resolveHandImmediately,
       dealNewHandNow: startNextHand,
+      getNextHandDebug: () => {
+        const roster = playersRef.current ?? players ?? [];
+        return {
+          dealing: dealingRef.current,
+          phase: phaseRef.current ?? phase,
+          renderedPhase: phase,
+          handId: handIdRef.current,
+          handCount: handCountRef.current,
+          breakState: tournamentBreakStateRef.current,
+          canContinue: canContinueGame(roster),
+          activePlayers: roster.filter(
+            (player) =>
+              player &&
+              !player.folded &&
+              !player.hasFolded &&
+              !player.seatOut &&
+              !player.isBusted &&
+              (Number(player.stack) > 0 || player.allIn),
+          ).length,
+        };
+      },
       forceDealNewHandNow: () => {
         const nextHandNumber = handCountRef.current + 1;
         const success = dealNewHandRef.current(
@@ -11005,27 +11105,7 @@ export default function App() {
       });
       return;
     }
-    if (mode === "tournament-mtt" && tournamentStateRef.current) {
-      const tournamentSummary =
-        buildTournamentHandSummaryFromPlayers(updatedPlayers);
-      if (tournamentSummary) {
-        const tableId =
-          heroTableIdRef.current ?? heroTableMetaRef.current.tableId;
-        recordHeroHandForReplay(tableId, tournamentSummary);
-        let nextState = onTableHandCompleted(
-          tournamentStateRef.current,
-          tableId,
-          tournamentSummary,
-        );
-        if (!nextState.isFinished) {
-          nextState = simulateBackgroundTables(nextState, tableId, {
-            maxHandsPerTable: 1,
-            onHandSimulated: recordCpuHandForReplay,
-          });
-        }
-        applyTournamentStateUpdate(nextState);
-      }
-    }
+    applyHeroTournamentHandCompletion(updatedPlayers);
     finishHand({
       playersSnapshot: updatedPlayers,
       summary: Array.isArray(summary) ? summary : [],

--- a/tests/e2e/helpers/gameProgressHelper.js
+++ b/tests/e2e/helpers/gameProgressHelper.js
@@ -396,19 +396,22 @@ export async function performSafeAction(page, options = {}) {
   if (!snapshot) {
     snapshot = await invokeE2E(page, "forceSeatAction", actor, payload);
   }
-  let changed = false;
-  if (!snapshot) {
-    await waitForProgressChange(page, beforeKey, { timeout: 3000 })
-      .then(() => {
-        changed = true;
-      })
-      .catch(() => {});
-  }
+  const changed = await waitForProgressChange(page, beforeKey, { timeout: 3000 })
+    .then(() => true)
+    .catch(() => false);
+  const controllerFailure = changed
+    ? null
+    : await invokeE2E(page, "getLastControllerActionFailure").catch(() => null);
   return {
-    acted: Boolean(snapshot) || changed,
+    // A returned snapshot is only an acknowledgement.  Long-running QA used
+    // to count stale/rejected snapshots as progress and spin until the whole
+    // test timed out.  Require the browser-visible canonical state to move.
+    acted: changed,
     clickedAction: `controller:${payload.type}`,
     actor,
     before: summarizeProgressState(progress),
+    snapshot: snapshot ? summarizeProgressState({ ...progress, snapshot }) : null,
+    controllerFailure,
   };
 }
 

--- a/tests/e2e/tournament-stage-blind-transition.spec.ts
+++ b/tests/e2e/tournament-stage-blind-transition.spec.ts
@@ -138,31 +138,7 @@ async function completeHeroHands(page: Page, hands: number, policy = "safe") {
       requireHeroButtonClick: false,
     });
     expect(result.status).toBe("PASS");
-    const nextHand = page.getByRole("button", { name: /Next Hand|次のハンド/i });
-    await expect(nextHand).toBeVisible({ timeout: 10_000 });
-    await nextHand.click({ timeout: 5_000 }).catch(async (error) => {
-      // A successful click immediately replaces the result controls. On long
-      // soaks Chromium can report that replacement as a detached locator even
-      // though the next hand is already live; only tolerate that exact state.
-      const phase = await page.evaluate(
-        () => window.__BADUGI_E2E__?.getStateSnapshot?.()?.phase,
-      );
-      if (["SHOWDOWN", "HAND_RESULT", "WAITING_NEXT_HAND"].includes(
-        String(phase ?? "").toUpperCase(),
-      )) {
-        throw error;
-      }
-    });
-    await page.waitForFunction(
-      () => {
-        const phase = window.__BADUGI_E2E__?.getStateSnapshot?.()?.phase;
-        return !["SHOWDOWN", "HAND_RESULT", "WAITING_NEXT_HAND"].includes(
-          String(phase ?? "").toUpperCase(),
-        );
-      },
-      undefined,
-      { timeout: 10_000 },
-    );
+    await advanceFromCompletedHand(page);
   }
 }
 
@@ -174,28 +150,54 @@ async function advanceFromCompletedHand(page: Page) {
       .click();
     await expect(breakOverlay).toBeHidden();
   }
-  const nextHand = page.getByRole("button", { name: /Next Hand|次のハンド/i });
-  await expect(nextHand).toBeVisible({ timeout: 10_000 });
-  await nextHand.click({ timeout: 5_000 }).catch(async (error) => {
-    const phase = await page.evaluate(
-      () => window.__BADUGI_E2E__?.getStateSnapshot?.()?.phase,
-    );
-    if (["SHOWDOWN", "HAND_RESULT", "WAITING_NEXT_HAND"].includes(
-      String(phase ?? "").toUpperCase(),
-    )) {
-      throw error;
-    }
+  const previous = await page.evaluate(() => {
+    const state = window.__BADUGI_E2E__?.getStateSnapshot?.() ?? null;
+    const snapshot = state?.controllerSnapshot ?? null;
+    return {
+      handId: snapshot?.handId ?? state?.handId ?? null,
+      resultVisible: Boolean(document.querySelector('[data-testid="hand-result-pot"]')),
+    };
   });
-  await page.waitForFunction(
-    () => {
-      const phase = window.__BADUGI_E2E__?.getStateSnapshot?.()?.phase;
-      return !["SHOWDOWN", "HAND_RESULT", "WAITING_NEXT_HAND"].includes(
-        String(phase ?? "").toUpperCase(),
-      );
-    },
-    undefined,
-    { timeout: 10_000 },
-  );
+  expect(
+    previous.resultVisible,
+    "a completed hand must expose its result before advancing",
+  ).toBe(true);
+  expect(
+    previous.handId,
+    "a completed tournament hand must have an identity",
+  ).toBeTruthy();
+  const nextHand = page
+    .getByRole("button", { name: /Next Hand|次のハンド/i })
+    .last();
+  await expect(nextHand).toBeVisible({ timeout: 10_000 });
+  await nextHand.click({ timeout: 5_000 }).catch(() => {});
+  try {
+    await page.waitForFunction(
+      (previousHandId) => {
+        const api = window.__BADUGI_E2E__;
+        const state = api?.getStateSnapshot?.() ?? null;
+        const snapshot = state?.controllerSnapshot ?? null;
+        const handId = snapshot?.handId ?? state?.handId ?? null;
+        const hud = api?.getTournamentHudState?.() ?? null;
+        const resultVisible = Boolean(
+          document.querySelector('[data-testid="hand-result-pot"]'),
+        );
+        if (hud?.isFinished || hud?.heroBusted) return true;
+        return !resultVisible && Boolean(handId) && handId !== previousHandId;
+      },
+      previous.handId,
+      { timeout: 10_000 },
+    );
+  } catch (error) {
+    const diagnostic = await page.evaluate(() => ({
+      nextHand: window.__BADUGI_E2E__?.getNextHandDebug?.() ?? null,
+      hud: window.__BADUGI_E2E__?.getTournamentHudState?.() ?? null,
+      resultVisible: Boolean(document.querySelector('[data-testid="hand-result-pot"]')),
+    }));
+    throw new Error(`Next hand did not start: ${JSON.stringify(diagnostic)}`, {
+      cause: error,
+    });
+  }
 }
 
 async function completeProductionTournament(page: Page, stageId: string) {


### PR DESCRIPTION
## Summary
- make player snapshots synchronous for controller transitions
- deduplicate tournament completion by physical table/hand ID
- derive tournament blind display from completed-hand authority
- queue one next-hand request during the short deal lock
- harden champion QA so one result cannot be counted repeatedly

## Local QA
- lint and production build PASS
- Tier1 2073 PASS, Tier2 165 PASS
- backend 69 PASS
- tournament browser QA 17/17, including store/local/world champions
- exact fifth-hand blind boundary 6/6 repeat
- store champion 8/8 repeat
- game progression 170 PASS, EV 25 PASS
- P2P UI 17 PASS + WebSocket/REST E2E 2 PASS
