### PR TITLE
fix(ai): preserve CPU decision attribution

### DIFF
--- a/docs/testing/MGX_QUALITY_PROGRAM_20260828.md
+++ b/docs/testing/MGX_QUALITY_PROGRAM_20260828.md
@@ -49,6 +49,7 @@ QA/QM result: **PASS for the 1–10 implementation scope**. Tasks 1–4 were int
 7. Tournament QA advances only when the visible result hand ID is replaced by a new physical hand ID. Re-reading one result can no longer masquerade as hundreds of completed hands.
 8. Tournament blind displays use the MTT engine's completed-hand counter as the authority. Store/local fifth-hand boundary tests prevent the ring controller from advancing a level one hand early.
 9. Tournament completion is idempotent by table and hand ID, and a Next Hand request made during the short deal lock is queued once instead of being discarded or double-dealt.
+10. CPU decision telemetry preserves policy source and AI tier through controller-backed actions. Live standard/pro checks require at least one attributed policy decision in both cash and tournament modes; unknown row counts alone cannot pass.
 
 ## Explicit boundaries
 

--- a/src/ui/App.jsx
+++ b/src/ui/App.jsx
@@ -3217,6 +3217,8 @@ export default function App() {
             betAfter: actorAfter.betThisRound ?? me.betThisRound,
             raiseCountTable: raiseCountThisRound,
             metadata: {
+              ...(payload?.metadata ?? {}),
+              ...payload,
               drawInfo: {
                 drawCount:
                   payload.discardIndexes?.length ??
@@ -4601,6 +4603,13 @@ export default function App() {
             betBefore: seatBefore?.betThisRound ?? 0,
             betAfter: actorAfter?.betThisRound ?? seatBefore?.betThisRound ?? 0,
             raiseCountTable: raiseCountThisRound,
+            // Preserve the policy/tier decision envelope through the
+            // controller bridge. Without it, controller-backed CPU actions
+            // are persisted as unattributed "unknown" decisions.
+            metadata: {
+              ...(payload?.metadata ?? {}),
+              ...payload,
+            },
           });
           forcedSeatActionsRef.current.delete(seat);
           helpers.syncLegacyFromControllerSnapshot(controllerOutcome.snapshot, {
@@ -4670,6 +4679,10 @@ export default function App() {
         betBefore,
         betAfter,
         raiseCountTable: raiseCountThisRound,
+        metadata: {
+          ...(payload?.metadata ?? {}),
+          ...payload,
+        },
       });
 
       if (actor.folded) {
@@ -12491,6 +12504,10 @@ export default function App() {
               betBefore: me.betThisRound ?? 0,
               betAfter: actorAfter?.betThisRound ?? me.betThisRound ?? 0,
               raiseCountTable: raiseCountThisRound,
+              metadata: {
+                ...(payload?.metadata ?? {}),
+                ...payload,
+              },
             });
             betHelpers.syncLegacyFromControllerSnapshot?.(
               controllerOutcome.snapshot,

--- a/tests/e2e/badugi-value-bet-observation.spec.ts
+++ b/tests/e2e/badugi-value-bet-observation.spec.ts
@@ -97,7 +97,19 @@ async function collectCpuTrace(page: Page, targetRows = 8) {
     await clickHeroIfNeeded(page);
     await page.waitForTimeout(450);
     const rows = await page.evaluate(() => window.__MGX_CPU_DECISION_TRACE__ ?? []);
-    if (Array.isArray(rows) && rows.length >= targetRows) return rows;
+    const hasAttributedPolicyDecision =
+      Array.isArray(rows) &&
+      rows.some((row) => {
+        const source = String(row?.decisionSource ?? "unknown");
+        return source !== "unknown" && source !== "forced";
+      });
+    if (
+      Array.isArray(rows) &&
+      rows.length >= targetRows &&
+      hasAttributedPolicyDecision
+    ) {
+      return rows;
+    }
   }
   return page.evaluate(() => window.__MGX_CPU_DECISION_TRACE__ ?? []);
 }
@@ -169,7 +181,13 @@ test("Badugi live CPU telemetry classifies friend-alpha runtime path and pressur
       const summary = summarizeRows(mode, rows);
       summaries.push(summary);
       expect(summary.decisions, `${mode} CPU telemetry rows`).toBeGreaterThan(0);
-      expect(summary.decisionSources, `${mode} source attribution`).not.toEqual({ unknown: summary.decisions });
+      expect(
+        Object.entries(summary.decisionSources).some(
+          ([source, count]) =>
+            source !== "unknown" && source !== "forced" && count > 0,
+        ),
+        `${mode} policy source attribution`,
+      ).toBe(true);
     } finally {
       await deleteAuthenticatedSession(page, session);
     }


### PR DESCRIPTION
## Summary
- preserve CPU policy source and AI tier through controller-backed bet/draw logging
- require a real attributed policy decision before live telemetry can pass
- reject a batch of unknown or forced rows as sufficient evidence

## Reproduction and verification
- reproduced production Pro failure: tournament decisions were all unknown
- local Pro cash: 8/8 pro-overlay, tier pro
- local Pro tournament: 6/6 pro-overlay, tier pro
- local standard and Pro live-style E2E PASS
- lint, production build, diff check PASS