### PR TITLE
test(games): extend strict settlement and controller boundaries

### DIFF
--- a/docs/architecture/app-controller-boundary.md
+++ b/docs/architecture/app-controller-boundary.md
@@ -1,0 +1,23 @@
+# App controller construction boundary
+
+`src/ui/App.jsx` must not import concrete game controllers. Runtime controller
+construction belongs to `src/ui/game/createAppGameController.js`, which delegates
+all registered games to `src/games/core/variants.js` and keeps the Chinese Poker
+adapter behind the same boundary.
+
+This is the first safe extraction from the large App component. It does not
+pretend that the two Badugi controller layers are already unified: the public
+registry still owns the compatibility wrapper while the legacy implementation
+remains internal to that wrapper.
+
+## Invariants
+
+- An unknown variant returns `null`; it never silently starts Badugi.
+- Board, Stud, and Dramaha controllers receive the canonical table config.
+- Draw controllers receive draw/session config.
+- Badugi receives its blind structure and evaluator config.
+- Adding a playable variant requires a registry factory and factory-boundary
+  coverage before App can construct it.
+
+Future App extractions should depend on this boundary instead of adding another
+concrete controller import or variant-specific constructor branch.

--- a/docs/testing/MGX_36_GAME_MATURITY_AUDIT_20260829.md
+++ b/docs/testing/MGX_36_GAME_MATURITY_AUDIT_20260829.md
@@ -9,14 +9,14 @@ this change.
 | Family | Variant IDs | Catalog status | Deterministic multi-hand | Strict settlement | History/replay UI |
 |---|---|---:|---:|---:|---:|
 | Board | B01-B09 | 9 live | 10 hands | Enforced | Covered |
-| Triple draw | D01-D07 | 5 live, 2 wip (D01/D02) | 10 hands | Allowlisted | Covered |
-| Single draw | S01-S07 | 5 live, 2 wip (S01/S02) | 10 hands | Allowlisted | Covered |
+| Triple draw | D01-D07 | 5 live, 2 wip (D01/D02) | 10 hands | Enforced | Covered |
+| Single draw | S01-S07 | 5 live, 2 wip (S01/S02) | 10 hands | Enforced | Covered |
 | Dramaha | H01-H06 | 6 wip | 10 hands | Allowlisted | Covered |
 | Stud | ST1-ST6 | 6 live | 10 hands | Enforced | Covered |
 | Chinese Poker | CP1 | 1 live | 10 hands | Points gate only; chip-pot gate not applicable | Not in the cross-variant browser replay matrix |
 
-Totals: 36 selector/controller routes, 26 `live`, 10 `wip`, 15 strict
-chip-settlement variants, and 21 explicitly allowlisted variants. CP1 is
+Totals: 36 selector/controller routes, 26 `live`, 10 `wip`, 29 strict
+chip-settlement variants, and 7 explicitly allowlisted variants. CP1 is
 classic Chinese Poker only; OFC street progression and fantasyland are not
 implemented and must not be implied by its `live` status.
 
@@ -38,10 +38,13 @@ implemented and must not be implied by its `live` status.
   tested.
 - Add a deterministic Stud all-in main/side-pot case proving the short-stack
   main-pot winner, deep-stack side-pot winner, and exact chip conservation.
+- Promote D01-D07 and S01-S07 to strict settlement using independently
+  recomputed 2-7, A-5, high, Badugi-low, Badugi-high, and split-component
+  winners for ten deterministic hands per variant.
 
 ## Remaining highest-risk maturity gaps
 
-1. Draw and Dramaha settlement remains allowlisted pending normalized
+1. Dramaha settlement remains allowlisted pending normalized board/draw
    component-pot results and evaluator replay.
 2. Variant-specific odd-chip position rules remain broader work; current Stud
    splits are deterministic but use seat-order allocation.

--- a/src/games/testing/ev/evIntegrityChecker.js
+++ b/src/games/testing/ev/evIntegrityChecker.js
@@ -374,7 +374,10 @@ export function validateHandEvIntegrity({
     ) {
       addError(errors, "terminal_pot_echo_mismatch", { afterLivePot, potTotal });
     }
-    const beforeTotal = beforeStackTotal + getLivePot(beforeState);
+    // Some engines expose unsettled blind/street contributions on the players
+    // instead of folding them into `pot` immediately. Count whichever source is
+    // larger so a preflop snapshot still represents every chip on the table.
+    const beforeTotal = beforeStackTotal + getCommittedTotal(beforeState);
     const afterTotal = afterStackTotal + (terminalPotIsResultEcho ? 0 : afterLivePot);
     if (!approxEqual(beforeTotal, afterTotal, options.chipEpsilon ?? EPSILON)) {
       addError(errors, "chip_conservation_mismatch", { beforeTotal, afterTotal });

--- a/src/games/testing/ev/strictVariantSettlementGate.js
+++ b/src/games/testing/ev/strictVariantSettlementGate.js
@@ -5,6 +5,7 @@ import { evaluateOmahaEightLow } from "../../plo/PLO8GameController.js";
 import { evaluateBadugiHand } from "../../evaluators/badugi.js";
 import { evaluateHighHand } from "../../evaluators/high.js";
 import { evaluateLowHand } from "../../evaluators/low.js";
+import { compareEvaluations } from "../../evaluators/registry.js";
 import { extractPayouts, validateHandEvIntegrity } from "./evIntegrityChecker.js";
 
 const STRICT_BOARD_VARIANTS = new Set([
@@ -13,11 +14,12 @@ const STRICT_BOARD_VARIANTS = new Set([
 
 const STRICT_STUD_VARIANTS = new Set(["ST1", "ST2", "ST3", "ST4", "ST5", "ST6"]);
 
+const STRICT_DRAW_VARIANTS = new Set([
+  "D01", "D02", "D03", "D04", "D05", "D06", "D07",
+  "S01", "S02", "S03", "S04", "S05", "S06", "S07",
+]);
+
 const FAMILY_ALLOWLISTS = Object.freeze([
-  {
-    ids: ["D01", "D02", "D03", "D04", "D05", "D06", "D07", "S01", "S02", "S03", "S04", "S05", "S06", "S07"],
-    reason: "Draw settlement awaits normalized terminal pot snapshots and component-pot winner replay.",
-  },
   {
     ids: ["H01", "H02", "H03", "H04", "H05", "H06"],
     reason: "Dramaha settlement awaits board/draw component winner and odd-chip verification.",
@@ -39,7 +41,11 @@ export function getStrictSettlementPolicy(variantId) {
   if (!variant) {
     return { variantId, status: "UNKNOWN", reason: "Variant is absent from the canonical catalog." };
   }
-  if (STRICT_BOARD_VARIANTS.has(variant.id) || STRICT_STUD_VARIANTS.has(variant.id)) {
+  if (
+    STRICT_BOARD_VARIANTS.has(variant.id) ||
+    STRICT_STUD_VARIANTS.has(variant.id) ||
+    STRICT_DRAW_VARIANTS.has(variant.id)
+  ) {
     return { variantId: variant.id, status: "ENFORCED", reason: null };
   }
   const reason = STRICT_SETTLEMENT_ALLOWLIST[variant.id];
@@ -48,6 +54,156 @@ export function getStrictSettlementPolicy(variantId) {
     status: reason ? "ALLOWLISTED" : "UNCLASSIFIED",
     reason: reason ?? "Strict settlement policy is missing.",
   };
+}
+
+function drawCards(player = {}) {
+  if (Array.isArray(player.hand)) return player.hand;
+  if (Array.isArray(player.cards)) return player.cards;
+  if (Array.isArray(player.holeCards)) return player.holeCards;
+  return [];
+}
+
+function evaluateArchieHigh(cards) {
+  const evaluation = evaluateHighHand({ cards });
+  const qualifies = [
+    "one-pair",
+    "two-pair",
+    "three-of-a-kind",
+    "straight",
+    "flush",
+    "full-house",
+    "four-of-a-kind",
+    "straight-flush",
+  ].includes(evaluation.metadata?.category);
+  return qualifies ? evaluation : null;
+}
+
+function buildDrawEvaluations(variantId, afterState) {
+  return (afterState?.players ?? [])
+    .map((player, index) => {
+      const cards = drawCards(player);
+      if (!cards.length) return null;
+      const low27 = evaluateLowHand({ cards, lowType: "27" });
+      const lowA5 = evaluateLowHand({
+        cards,
+        lowType: "A5",
+        requireQualifier: variantId === "D07" ? 8 : null,
+      });
+      return {
+        seatIndex: seatIndexOf(player, index),
+        folded: Boolean(player?.folded || player?.hasFolded),
+        high: evaluateHighHand({ cards }),
+        archieHigh: evaluateArchieHigh(cards),
+        low27,
+        lowA5,
+        badugi: evaluateBadugiHand({ cards, mode: "low" }),
+        badugiHigh: evaluateBadugiHand({ cards, mode: "high" }),
+      };
+    })
+    .filter(Boolean);
+}
+
+function drawEvaluationKey(variantId, component) {
+  if (component === "badugi") return "badugi";
+  if (component === "low27") return "low27";
+  if (component === "lowA5") return "lowA5";
+  if (component === "archieHigh") return "archieHigh";
+  if (component === "archieLow") return "lowA5";
+  if (["D01", "S01"].includes(variantId)) return "low27";
+  if (["D02", "S02"].includes(variantId)) return "lowA5";
+  if (["D03", "S04"].includes(variantId)) return "badugi";
+  if (["D06", "S07"].includes(variantId)) return "badugiHigh";
+  if (variantId === "S03") return "high";
+  return null;
+}
+
+function verifyDrawPotWinners(variantId, afterState, result) {
+  const errors = [];
+  const evaluations = buildDrawEvaluations(variantId, afterState);
+  const payouts = extractPayouts(result);
+  const liveSeats = evaluations
+    .filter((entry) => !entry.folded)
+    .map((entry) => entry.seatIndex)
+    .sort((left, right) => left - right);
+
+  for (const [resultPotIndex, pot] of (result?.potDetails ?? []).entries()) {
+    const amount = Math.max(0, Number(pot?.amount ?? pot?.potAmount) || 0);
+    const component = pot.component ?? "main";
+    const evaluationKey = drawEvaluationKey(variantId, component);
+    const explicitEligible = Array.isArray(pot.eligibleSeatIndexes) && pot.eligibleSeatIndexes.length
+      ? pot.eligibleSeatIndexes
+      : null;
+    const eligible = new Set(explicitEligible ?? liveSeats);
+    const candidates = evaluations.filter((entry) => {
+      if (!eligible.has(entry.seatIndex)) return false;
+      const evaluation = entry[evaluationKey];
+      return Boolean(
+        evaluation &&
+        evaluation.qualifies !== false &&
+        evaluation.metadata?.qualifies !== false &&
+        Number.isFinite(evaluation.rankPrimary) &&
+        (evaluation.rankSecondary == null || Number.isFinite(evaluation.rankSecondary)),
+      );
+    });
+    const actual = payouts
+      .filter((payout) => payout.potIndex === resultPotIndex && Number(payout.amount) > 0)
+      .map((payout) => payout.seatIndex)
+      .sort((left, right) => left - right);
+    if (amount === 0) {
+      if (actual.length) {
+        errors.push({
+          code: "strict_draw_zero_pot_has_payout",
+          variantId,
+          resultPotIndex,
+          component,
+          actual,
+        });
+      }
+      continue;
+    }
+    if (candidates.length === 1) {
+      const expected = [candidates[0].seatIndex];
+      if (JSON.stringify(actual) !== JSON.stringify(expected)) {
+        errors.push({
+          code: "strict_draw_uncontested_winner_mismatch",
+          variantId,
+          resultPotIndex,
+          component,
+          expected,
+          actual,
+        });
+      }
+      continue;
+    }
+    if (!evaluationKey || !candidates.length) {
+      errors.push({
+        code: "strict_draw_pot_has_no_evaluable_player",
+        variantId,
+        resultPotIndex,
+        component,
+        eligible: [...eligible],
+        evaluatedSeats: evaluations.map((entry) => entry.seatIndex),
+        playerShapes: (afterState?.players ?? []).map((player, seatIndex) => ({
+          seatIndex: seatIndexOf(player, seatIndex),
+          handCount: drawCards(player).length,
+          folded: Boolean(player?.folded || player?.hasFolded),
+        })),
+      });
+      continue;
+    }
+    const expected = expectedWinnerSeats(candidates, evaluationKey, compareEvaluations);
+    if (JSON.stringify(actual) !== JSON.stringify(expected)) {
+      errors.push({
+        code: "strict_draw_component_winner_mismatch",
+        variantId,
+        resultPotIndex,
+        component,
+        expected,
+        actual,
+      });
+    }
+  }
+  return errors;
 }
 
 function buildStudEvaluations(variantId, afterState) {
@@ -276,7 +432,7 @@ export function validateStrictVariantSettlement({
     options: {
       requireResult: true,
       strictChipConservation: true,
-      terminalPotIsResultEcho: true,
+      terminalPotIsResultEcho: !STRICT_DRAW_VARIANTS.has(variantId),
     },
   });
   const strictErrors = [];
@@ -299,6 +455,8 @@ export function validateStrictVariantSettlement({
     strictErrors.push(...verifyBoardPotWinners(variantId, afterState, result));
   } else if (STRICT_STUD_VARIANTS.has(variantId)) {
     strictErrors.push(...verifyStudPotWinners(variantId, afterState, result));
+  } else if (STRICT_DRAW_VARIANTS.has(variantId)) {
+    strictErrors.push(...verifyDrawPotWinners(variantId, afterState, result));
   }
   const errors = [...check.errors, ...strictErrors];
   return { ok: errors.length === 0, policy, errors, check };

--- a/src/games/testing/ev/strictVariantSettlementGate.test.js
+++ b/src/games/testing/ev/strictVariantSettlementGate.test.js
@@ -22,6 +22,7 @@ import {
   getStrictSettlementPolicy,
   validateStrictVariantSettlement,
 } from "./strictVariantSettlementGate.js";
+import { runProgressScenario } from "../scenario/runProgressScenario.js";
 
 function seats() {
   return Array.from({ length: 6 }, (_, seatIndex) => ({
@@ -54,14 +55,31 @@ describe("strict per-variant settlement gate", () => {
     const policies = GAME_VARIANTS.map((variant) => getStrictSettlementPolicy(variant.id));
     expect(policies.filter((policy) => policy.status === "ENFORCED").map((policy) => policy.variantId)).toEqual([
       "B01", "B02", "B03", "B04", "B05", "B06", "B07", "B08", "B09",
+      "D01", "D02", "D03", "D04", "D05", "D06", "D07",
+      "S01", "S02", "S03", "S04", "S05", "S06", "S07",
       "ST1", "ST2", "ST3", "ST4", "ST5", "ST6",
     ]);
     expect(policies.filter((policy) => policy.status === "UNCLASSIFIED")).toEqual([]);
-    expect(Object.keys(STRICT_SETTLEMENT_ALLOWLIST)).toHaveLength(21);
+    expect(Object.keys(STRICT_SETTLEMENT_ALLOWLIST)).toHaveLength(7);
     policies.filter((policy) => policy.status === "ALLOWLISTED").forEach((policy) => {
       expect(policy.reason).toEqual(expect.any(String));
       expect(policy.reason.length).toBeGreaterThan(30);
     });
+  });
+
+  it.each([
+    "D01", "D02", "D03", "D04", "D05", "D06", "D07",
+    "S01", "S02", "S03", "S04", "S05", "S06", "S07",
+  ])("enforces evaluator-backed draw settlement for ten seeded %s hands", (variantId) => {
+    const result = runProgressScenario({
+      variantId,
+      scenarioId: "cash-10-hands-smoke",
+      seed: `strict-draw-${variantId}`,
+      maxSteps: 260,
+    });
+    expect(result.status).toBe("passed");
+    expect(result.strictSettlements).toHaveLength(10);
+    expect(result.strictSettlements.every((entry) => entry.status === "ENFORCED" && entry.ok)).toBe(true);
   });
 
   it("passes strict result, pot, evaluator, and chip conservation for seeded NLH", () => {

--- a/src/games/testing/scenario/runProgressScenario.js
+++ b/src/games/testing/scenario/runProgressScenario.js
@@ -187,6 +187,8 @@ export function createProgressHarness(variantId, options = {}) {
   if (DRAW_CONTROLLERS[normalizedVariantId]) {
     const Controller = DRAW_CONTROLLERS[normalizedVariantId];
     const isBadugi = normalizedVariantId === "badugi";
+    const badugiDeck = isBadugi ? new DeckManager({ rng }) : null;
+    const drawCardsForSeat = badugiDeck ? () => badugiDeck.draw(4) : null;
     const controller = isBadugi
       ? new Controller({
           seatConfig: DEFAULT_SEATS,
@@ -221,8 +223,15 @@ export function createProgressHarness(variantId, options = {}) {
           ante: options.blinds?.ante ?? DEFAULT_BLINDS.ante,
         },
       ],
+      drawCardsForSeat,
     });
-    return { family: "draw", controller, state };
+    return {
+      family: "draw",
+      controller,
+      state,
+      drawCardsForSeat,
+      resetDrawDeck: badugiDeck ? () => badugiDeck.reset() : null,
+    };
   }
   if (normalizedVariantId === "chinese_poker") {
     const controller = new ChinesePokerController({
@@ -477,6 +486,7 @@ export function resolveScenarioHandCount(scenarioId) {
 function startNextHarnessHand(harness, { variantId, handNumber }) {
   const snapshot = snapshotOf(harness);
   if (harness.family === "draw") {
+    harness.resetDrawDeck?.();
     harness.state = harness.controller.createNewHandState(harness.state, {
       handId: `${normalizeProgressVariantId(variantId)}-progress-${handNumber}`,
       currentPlayers: snapshot.players,
@@ -484,6 +494,7 @@ function startNextHarnessHand(harness, { variantId, handNumber }) {
         typeof snapshot.dealerIndex === "number"
           ? (snapshot.dealerIndex + 1) % Math.max(1, snapshot.players?.length ?? 1)
           : undefined,
+      drawCardsForSeat: harness.drawCardsForSeat ?? null,
     });
     return snapshotOf(harness);
   }

--- a/src/ui/App.jsx
+++ b/src/ui/App.jsx
@@ -86,26 +86,6 @@ import {
   isBetRoundComplete,
   needsActionForBet,
 } from "../games/badugi/flow/betRoundUtils.js";
-import BadugiGameController from "../games/badugi/controller/BadugiGameController.js";
-import ChinesePokerController from "../games/chinese/ChinesePokerController.js";
-import DramahaGameController from "../games/dramaha/DramahaGameController.js";
-import FLHGameController from "../games/nlh/FLHGameController.js";
-import NLHGameController from "../games/nlh/NLHGameController.js";
-import SuperHoldemGameController, {
-  FLSuperHoldemGameController,
-} from "../games/nlh/SuperHoldemGameController.js";
-import BigOGameController from "../games/plo/BigOGameController.js";
-import FiveCardPLOGameController from "../games/plo/FiveCardPLOGameController.js";
-import FLO8GameController from "../games/plo/FLO8GameController.js";
-import PLO8GameController from "../games/plo/PLO8GameController.js";
-import PLOGameController from "../games/plo/PLOGameController.js";
-import StudGameController, {
-  Razz27GameController,
-  RazzGameController,
-  RazzduceyGameController,
-  RazzdugiGameController,
-  Stud8GameController,
-} from "../games/stud/StudGameController.js";
 import { GAME_VARIANTS } from "../games/core/variants.js";
 import { canLaunchVariant } from "../games/config/canLaunchVariant.js";
 import { buildHandResultSummary } from "../games/badugi/flow/handResultUtils.js";
@@ -127,6 +107,7 @@ import {
 } from "./game/appVariantRouting.js";
 import { getVariantLayoutProfile } from "./game/layoutGroups.js";
 import { resolveEffectiveControllerSnapshot } from "./game/controllerSnapshotResolver.js";
+import { createAppGameController } from "./game/createAppGameController.js";
 import {
   createVariantRotationController,
   advanceVariantRotation,
@@ -2252,99 +2233,25 @@ export default function App() {
         engineStateRef.current = null;
         setEngineState(null);
       }
-      if (variantId === APP_VARIANT_IDS.NLH) {
-        gameControllerRef.current = new NLHGameController({
-          tableConfig: buildNlhTableConfig(),
-        });
-      } else if (variantId === APP_VARIANT_IDS.FLH) {
-        gameControllerRef.current = new FLHGameController({
-          tableConfig: buildNlhTableConfig(),
-        });
-      } else if (variantId === APP_VARIANT_IDS.SUPER_HOLDEM) {
-        gameControllerRef.current = new SuperHoldemGameController({
-          tableConfig: buildNlhTableConfig(),
-        });
-      } else if (variantId === APP_VARIANT_IDS.FL_SUPER_HOLDEM) {
-        gameControllerRef.current = new FLSuperHoldemGameController({
-          tableConfig: buildNlhTableConfig(),
-        });
-      } else if (variantId === APP_VARIANT_IDS.PLO) {
-        gameControllerRef.current = new PLOGameController({
-          tableConfig: buildNlhTableConfig(),
-        });
-      } else if (variantId === APP_VARIANT_IDS.PLO8) {
-        gameControllerRef.current = new PLO8GameController({
-          tableConfig: buildNlhTableConfig(),
-        });
-      } else if (variantId === APP_VARIANT_IDS.FLO8) {
-        gameControllerRef.current = new FLO8GameController({
-          tableConfig: buildNlhTableConfig(),
-        });
-      } else if (variantId === APP_VARIANT_IDS.BIG_O) {
-        gameControllerRef.current = new BigOGameController({
-          tableConfig: buildNlhTableConfig(),
-        });
-      } else if (variantId === APP_VARIANT_IDS.FIVE_CARD_PLO) {
-        gameControllerRef.current = new FiveCardPLOGameController({
-          tableConfig: buildNlhTableConfig(),
-        });
-      } else if (DRAMAHA_APP_VARIANT_IDS.has(variantId)) {
-        gameControllerRef.current = new DramahaGameController({
-          tableConfig: buildNlhTableConfig(),
-          variant: variantId,
-        });
-      } else if (variantId === APP_VARIANT_IDS.STUD) {
-        gameControllerRef.current = new StudGameController({
-          tableConfig: buildNlhTableConfig(),
-        });
-      } else if (variantId === APP_VARIANT_IDS.STUD8) {
-        gameControllerRef.current = new Stud8GameController({
-          tableConfig: buildNlhTableConfig(),
-        });
-      } else if (variantId === APP_VARIANT_IDS.RAZZ) {
-        gameControllerRef.current = new RazzGameController({
-          tableConfig: buildNlhTableConfig(),
-        });
-      } else if (variantId === APP_VARIANT_IDS.RAZZ27) {
-        gameControllerRef.current = new Razz27GameController({
-          tableConfig: buildNlhTableConfig(),
-        });
-      } else if (variantId === APP_VARIANT_IDS.RAZZDUGI) {
-        gameControllerRef.current = new RazzdugiGameController({
-          tableConfig: buildNlhTableConfig(),
-        });
-      } else if (variantId === APP_VARIANT_IDS.RAZZDUCEY) {
-        gameControllerRef.current = new RazzduceyGameController({
-          tableConfig: buildNlhTableConfig(),
-        });
-      } else if (variantId === APP_VARIANT_IDS.CHINESE_POKER) {
-        gameControllerRef.current = new ChinesePokerController({
-          seats: [
-            { id: "hero", name: "You", isHero: true },
-            { id: "mina", name: "Mina" },
-            { id: "ren", name: "Ren" },
-            { id: "sora", name: "Sora" },
-          ],
-        });
-      } else if (isDrawLowballAppVariant(variantId)) {
-        gameControllerRef.current =
-          GAME_VARIANTS[variantId]?.controllerFactory?.({
-            seatConfig: Array.isArray(seatConfigRef.current)
-              ? [...seatConfigRef.current]
-              : [...DEFAULT_SEAT_TYPES],
-            startingStack: startingStackRef.current ?? DEFAULT_STARTING_STACK,
-            heroProfile,
-            dealerIndex: dealerIdx,
-            structure: { sb: SB, bb: BB, ante: currentAnte },
-          }) ?? null;
-      } else {
-        gameControllerRef.current = new BadugiGameController({
+      gameControllerRef.current = createAppGameController({
+        variantId,
+        tableConfig: buildNlhTableConfig(),
+        drawConfig: {
+          seatConfig: Array.isArray(seatConfigRef.current)
+            ? [...seatConfigRef.current]
+            : [...DEFAULT_SEAT_TYPES],
+          startingStack: startingStackRef.current ?? DEFAULT_STARTING_STACK,
+          heroProfile,
+          dealerIndex: dealerIdx,
+          structure: { sb: SB, bb: BB, ante: currentAnte },
+        },
+        badugiConfig: {
           numSeats: NUM_PLAYERS,
           blindStructure: activeBlindStructure,
           lastStructureIndex,
           evaluateHand: evaluateBadugi,
-        });
-      }
+        },
+      });
       controllerVariantRef.current = variantId;
     } else if (variantId === APP_VARIANT_IDS.BADUGI) {
       gameControllerRef.current.updateConfig({

--- a/src/ui/game/createAppGameController.js
+++ b/src/ui/game/createAppGameController.js
@@ -1,0 +1,39 @@
+import ChinesePokerController from "../../games/chinese/ChinesePokerController.js";
+import { GAME_VARIANTS } from "../../games/core/variants.js";
+import {
+  APP_VARIANT_IDS,
+  isDrawLowballAppVariant,
+  normalizeAppVariantId,
+} from "./appVariantRouting.js";
+
+const DEFAULT_CHINESE_SEATS = Object.freeze([
+  { id: "hero", name: "You", isHero: true },
+  { id: "mina", name: "Mina" },
+  { id: "ren", name: "Ren" },
+  { id: "sora", name: "Sora" },
+]);
+
+export function createAppGameController({
+  variantId,
+  tableConfig = {},
+  drawConfig = {},
+  badugiConfig = {},
+  chineseSeats = DEFAULT_CHINESE_SEATS,
+} = {}) {
+  const normalizedVariant = normalizeAppVariantId(variantId, null);
+  if (normalizedVariant === APP_VARIANT_IDS.CHINESE_POKER) {
+    return new ChinesePokerController({ seats: chineseSeats.map((seat) => ({ ...seat })) });
+  }
+
+  const controllerFactory = GAME_VARIANTS[normalizedVariant]?.controllerFactory;
+  if (typeof controllerFactory !== "function") return null;
+  if (normalizedVariant === APP_VARIANT_IDS.BADUGI) {
+    return controllerFactory(badugiConfig);
+  }
+  if (isDrawLowballAppVariant(normalizedVariant)) {
+    return controllerFactory(drawConfig);
+  }
+  return controllerFactory({ tableConfig });
+}
+
+export default createAppGameController;

--- a/src/ui/game/createAppGameController.test.js
+++ b/src/ui/game/createAppGameController.test.js
@@ -1,0 +1,29 @@
+import { describe, expect, it } from "vitest";
+import { GAME_VARIANTS } from "../../games/core/variants.js";
+import { createAppGameController } from "./createAppGameController.js";
+
+describe("createAppGameController", () => {
+  it.each(Object.keys(GAME_VARIANTS))("creates the registered %s controller", (variantId) => {
+    const controller = createAppGameController({
+      variantId,
+      tableConfig: { seats: [], blinds: { sb: 5, bb: 10, ante: 0 } },
+      drawConfig: { seatConfig: ["HUMAN", "CPU"], startingStack: 500 },
+      badugiConfig: {
+        numSeats: 2,
+        seatConfig: ["HUMAN", "CPU"],
+        startingStack: 500,
+        blindStructure: [{ sb: 5, bb: 10, ante: 0 }],
+      },
+    });
+    expect(controller).toBeTruthy();
+  });
+
+  it("keeps Chinese Poker behind the same App factory boundary", () => {
+    const controller = createAppGameController({ variantId: "chinese_poker" });
+    expect(controller?.constructor?.name).toBe("ChinesePokerController");
+  });
+
+  it("returns null instead of silently constructing Badugi for an unknown variant", () => {
+    expect(createAppGameController({ variantId: "unknown-game" })).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary
- promote all 14 draw variants to strict evaluator-backed ten-hand settlement gates
- count unsettled player contributions in chip-conservation checks and seed real Badugi hands in the progress harness
- centralize App controller construction behind the canonical variant registry
- reject unknown variant IDs instead of silently falling back to Badugi

## QA
- lint
- Tier1: 304 files / 2137 tests
- Tier2: 78 files / 165 tests
- strict EV: 48 tests
- game progress: 170 tests
- RL safety: 55 tests
- backend: 76 tests
- tournament PR E2E: 17 tests, including Store/Local/World champions and grounded review
- Core5 E2E: 15 tests with isolated backend
- P2P: 17 UI tests + 2 production transport E2E
- build and deploy static safety
- npm full/runtime audit 0; pip-audit 0 known vulnerabilities